### PR TITLE
Repo is moved to meta-pytorch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,47 @@
+# Copilot Instructions for TritonParse
+
+## Project Overview
+- **TritonParse** is a Python tool for visualizing and analyzing Triton kernel compilation and launch traces. It integrates tightly with Triton and PyTorch workflows, providing structured logging and IR comparison.
+- The frontend is a React/Vite/TypeScript webapp (see `website/`), while the backend is Python (see `tritonparse/`).
+
+## Key Components
+- `tritonparse/structured_logging.py`: Core for logging kernel launches and compilation events, including stack traces and source mapping.
+- `tritonparse/utils.py`: Main entry for parsing logs and generating output files (`.ndjson.gz`).
+- `tritonparse/sourcemap_utils.py`: Utilities for stack trace analysis, session ID extraction, and source mapping.
+- `tests/`: Contains both automated (unittest) and manual test scripts. See `tests/test_tritonparse.py` for main test suite.
+- `website/`: Web UI for visualizing trace files. No backend server required; all processing is client-side.
+
+## Developer Workflows
+- **Build/Install**: `pip install -e .` (Python ≥3.10, Triton >3.3.1 required)
+- **Generate Traces**: Use `tritonparse.structured_logging.init()` in your Triton/PyTorch code, then run `tritonparse.utils.unified_parse()` to produce trace files.
+- **Run Tests**: `python -m unittest tests.test_tritonparse -v` (see `tests/README.md` for details)
+- **Manual Test**: `python tests/test_add.py` (generates logs and parses them)
+- **CI Scripts**: Use `.ci/*.sh` for environment setup, Triton install, and test runs. See `.ci/README.md` for workflow.
+
+## Patterns & Conventions
+- **Session ID Extraction**: Session IDs for autotune are derived from stack traces (see `get_autotune_session_id` in `sourcemap_utils.py`). The logic may need to distinguish user code from framework/runtime code.
+- **Test Isolation**: Each test defines its own kernel to avoid cache interference. CUDA tests are skipped if no GPU is available.
+- **Log Output**: All logs and parsed outputs are written to `tests/parsed_output/` or user-specified directories.
+- **Environment Variables**: Commonly used for controlling debug, cache, and device selection (e.g., `TRITONPARSE_DEBUG=1`, `TORCHINDUCTOR_FX_GRAPH_CACHE=0`).
+
+## Integration Points
+- **Triton**: Must be installed from source for full feature support. See `pyproject.toml` and README for details.
+- **PyTorch**: Used in tests and example kernels.
+- **Web UI**: Consumes `.ndjson.gz` trace files for visualization. No server required.
+
+## Troubleshooting
+- If logs are missing, check Triton installation and ensure logging is enabled.
+- For test failures, verify CUDA availability and correct environment setup.
+- Use debug mode (`TRITONPARSE_DEBUG=1`) for verbose output.
+
+## References
+- See `README.md` (project root) for quick start, features, and documentation links.
+- See `tests/README.md` for test structure and commands.
+- See `.ci/README.md` for CI and environment setup scripts.
+
+---
+
+**For new agents:**
+- Always check for the latest conventions in the above files before making changes.
+- Prefer using provided utility functions and logging mechanisms over custom implementations.
+- When analyzing stack traces or session IDs, refer to `sourcemap_utils.py` and related test cases for expected patterns.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,11 @@ jobs:
 
             - name: Check code formatting
               run: |
-                  make format-check || (echo "❌ Format check failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/pytorch-labs/tritonparse/wiki/05.-Code-Formatting" && exit 1)
+                  make format-check || (echo "❌ Format check failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
 
             - name: Check linting
               run: |
-                  make lint-check || (echo "❌ Linting failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/pytorch-labs/tritonparse/wiki/05.-Code-Formatting" && exit 1)
+                  make lint-check || (echo "❌ Linting failed. Please run 'make format' to fix formatting issues, then commit the changes." && echo "📖 For detailed formatting guide, see: https://github.com/meta-pytorch/tritonparse/wiki/05.-Code-Formatting" && exit 1)
 
     test-from-source:
         runs-on: 4-core-ubuntu-gpu-t4

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-
+*.mdc
 
 # end

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # TritonParse
 
 [![License: BSD-3](https://img.shields.io/badge/License-BSD--3-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Deploy-brightgreen)](https://pytorch-labs.github.io/tritonparse/)
+[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Deploy-brightgreen)](https://meta-pytorch.github.io/tritonparse/)
 
 **A comprehensive visualization and analysis tool for Triton IR files** — helping developers analyze, debug, and understand Triton kernel compilation processes.
 
-🌐 **[Try it online →](https://pytorch-labs.github.io/tritonparse/?json_url=https://pytorch-labs.github.io/tritonparse/dedicated_log_triton_trace_findhao__mapped.ndjson.gz)**
+🌐 **[Try it online →](https://meta-pytorch.github.io/tritonparse/?json_url=https://meta-pytorch.github.io/tritonparse/dedicated_log_triton_trace_findhao__mapped.ndjson.gz)**
 
 ## ✨ Key Features
 
@@ -56,7 +56,7 @@ INFO:tritonparse:Copying parsed logs from /tmp/tmp1gan7zky to /scratch/findhao/t
 
 ### 2. Visualize Results
 
-**Visit [https://pytorch-labs.github.io/tritonparse/](https://pytorch-labs.github.io/tritonparse/?json_url=https://pytorch-labs.github.io/tritonparse/dedicated_log_triton_trace_findhao__mapped.ndjson.gz)** and open your local trace files (.ndjson.gz format).
+**Visit [https://meta-pytorch.github.io/tritonparse/](https://meta-pytorch.github.io/tritonparse/?json_url=https://meta-pytorch.github.io/tritonparse/dedicated_log_triton_trace_findhao__mapped.ndjson.gz)** and open your local trace files (.ndjson.gz format).
 
 > **🔒 Privacy Note**: Your trace files are processed entirely in your browser - nothing is uploaded to any server!
 
@@ -80,12 +80,12 @@ pip install triton
 
 | 📖 Guide | Description |
 |----------|-------------|
-| **[🏠 Wiki Home](https://github.com/pytorch-labs/tritonparse/wiki)** | Complete documentation and navigation |
-| **[📦 Installation Guide](https://github.com/pytorch-labs/tritonparse/wiki/01.-Installation)** | Detailed setup for all scenarios |
-| **[📋 Usage Guide](https://github.com/pytorch-labs/tritonparse/wiki/02.-Usage-Guide)** | Complete workflow and examples |
-| **[🌐 Web Interface Guide](https://github.com/pytorch-labs/tritonparse/wiki/03.-Web-Interface-Guide)** | Master the visualization interface |
-| **[🔧 Developer Guide](https://github.com/pytorch-labs/tritonparse/wiki/04.-Developer-Guide)** | Contributing and development setup |
-| **[❓ FAQ](https://github.com/pytorch-labs/tritonparse/wiki/06.-FAQ)** | Frequently asked questions |
+| **[🏠 Wiki Home](https://github.com/meta-pytorch/tritonparse/wiki)** | Complete documentation and navigation |
+| **[📦 Installation Guide](https://github.com/meta-pytorch/tritonparse/wiki/01.-Installation)** | Detailed setup for all scenarios |
+| **[📋 Usage Guide](https://github.com/meta-pytorch/tritonparse/wiki/02.-Usage-Guide)** | Complete workflow and examples |
+| **[🌐 Web Interface Guide](https://github.com/meta-pytorch/tritonparse/wiki/03.-Web-Interface-Guide)** | Master the visualization interface |
+| **[🔧 Developer Guide](https://github.com/meta-pytorch/tritonparse/wiki/04.-Developer-Guide)** | Contributing and development setup |
+| **[❓ FAQ](https://github.com/meta-pytorch/tritonparse/wiki/06.-FAQ)** | Frequently asked questions |
 
 ## 🛠️ Tech Stack
 
@@ -103,7 +103,7 @@ Each stage can be inspected and compared to understand optimization transformati
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see our **[Developer Guide](https://github.com/pytorch-labs/tritonparse/wiki/04.-Developer-Guide)** for:
+We welcome contributions! Please see our **[Developer Guide](https://github.com/meta-pytorch/tritonparse/wiki/04.-Developer-Guide)** for:
 - Development setup
 - Code formatting standards
 - Pull request process
@@ -111,9 +111,9 @@ We welcome contributions! Please see our **[Developer Guide](https://github.com/
 
 ## 📞 Support & Community
 
-- **🐛 Report Issues**: [GitHub Issues](https://github.com/pytorch-labs/tritonparse/issues)
-- **💬 Discussions**: [GitHub Discussions](https://github.com/pytorch-labs/tritonparse/discussions)
-- **📚 Documentation**: [TritonParse Wiki](https://github.com/pytorch-labs/tritonparse/wiki)
+- **🐛 Report Issues**: [GitHub Issues](https://github.com/meta-pytorch/tritonparse/issues)
+- **💬 Discussions**: [GitHub Discussions](https://github.com/meta-pytorch/tritonparse/discussions)
+- **📚 Documentation**: [TritonParse Wiki](https://github.com/meta-pytorch/tritonparse/wiki)
 
 ## 📄 License
 
@@ -121,4 +121,4 @@ This project is licensed under the BSD-3 License - see the [LICENSE](LICENSE) fi
 
 ---
 
-**✨ Ready to get started?** Visit our **[Installation Guide](https://github.com/pytorch-labs/tritonparse/wiki/01.-Installation)** or try the **[online tool](https://pytorch-labs.github.io/tritonparse/)** directly!
+**✨ Ready to get started?** Visit our **[Installation Guide](https://github.com/meta-pytorch/tritonparse/wiki/01.-Installation)** or try the **[online tool](https://meta-pytorch.github.io/tritonparse/)** directly!

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # TritonParse
 
 [![License: BSD-3](https://img.shields.io/badge/License-BSD--3-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Deploy-brightgreen)](https://meta-pytorch.github.io/tritonparse/)
+[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Deploy-brightgreen)](https://meta-pytorch.org/tritonparse/)
 
 **A comprehensive visualization and analysis tool for Triton IR files** — helping developers analyze, debug, and understand Triton kernel compilation processes.
 
-🌐 **[Try it online →](https://meta-pytorch.github.io/tritonparse/?json_url=https://meta-pytorch.github.io/tritonparse/dedicated_log_triton_trace_findhao__mapped.ndjson.gz)**
+🌐 **[Try it online →](https://meta-pytorch.org/tritonparse/?json_url=https://meta-pytorch.org/tritonparse/dedicated_log_triton_trace_findhao__mapped.ndjson.gz)**
 
 ## ✨ Key Features
 
@@ -56,7 +56,7 @@ INFO:tritonparse:Copying parsed logs from /tmp/tmp1gan7zky to /scratch/findhao/t
 
 ### 2. Visualize Results
 
-**Visit [https://meta-pytorch.github.io/tritonparse/](https://meta-pytorch.github.io/tritonparse/?json_url=https://meta-pytorch.github.io/tritonparse/dedicated_log_triton_trace_findhao__mapped.ndjson.gz)** and open your local trace files (.ndjson.gz format).
+**Visit [https://meta-pytorch.org/tritonparse/](https://meta-pytorch.org/tritonparse/?json_url=https://meta-pytorch.org/tritonparse/dedicated_log_triton_trace_findhao__mapped.ndjson.gz)** and open your local trace files (.ndjson.gz format).
 
 > **🔒 Privacy Note**: Your trace files are processed entirely in your browser - nothing is uploaded to any server!
 
@@ -121,4 +121,4 @@ This project is licensed under the BSD-3 License - see the [LICENSE](LICENSE) fi
 
 ---
 
-**✨ Ready to get started?** Visit our **[Installation Guide](https://github.com/meta-pytorch/tritonparse/wiki/01.-Installation)** or try the **[online tool](https://meta-pytorch.github.io/tritonparse/)** directly!
+**✨ Ready to get started?** Visit our **[Installation Guide](https://github.com/meta-pytorch/tritonparse/wiki/01.-Installation)** or try the **[online tool](https://meta-pytorch.org/tritonparse/)** directly!

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ INFO:tritonparse:Copying parsed logs from /tmp/tmp1gan7zky to /scratch/findhao/t
 
 **For basic usage (trace generation):**
 ```bash
-git clone https://github.com/pytorch-labs/tritonparse.git
+git clone https://github.com/meta-pytorch/tritonparse.git
 cd tritonparse
 pip install -e .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,4 @@ sorter = "usort"
 first_party_detection = false
 
 [project.urls]
-"Homepage" = "https://github.com/pytorch-labs/tritonparse"
+"Homepage" = "https://github.com/meta-pytorch/tritonparse"

--- a/tritonparse/tools/decompress_bin_ndjson.py
+++ b/tritonparse/tools/decompress_bin_ndjson.py
@@ -49,7 +49,7 @@ def decompress_bin_ndjson(input_file: str, output_file: str = None) -> None:
     try:
         line_count = 0
         # Because we use NDJSON format, each line is a complete JSON record.
-        # It is guruanteed here https://github.com/pytorch-labs/tritonparse/blob/
+        # It is guruanteed here https://github.com/meta-pytorch/tritonparse/blob/
         # c8dcc2a94ac10ede4342dba7456f6ebd8409b95d/tritonparse/structured_logging.py#L320
         with gzip.open(input_path, "rt", encoding="utf-8") as compressed_file:
             with open(output_path, "w", encoding="utf-8") as output:

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -386,7 +386,7 @@ function App() {
               {/* GitHub and Wiki Links */}
               <div className="flex items-center space-x-4">
                 <ExternalLink
-                  href="https://github.com/pytorch-labs/tritonparse"
+                  href="https://github.com/meta-pytorch/tritonparse"
                   title="View on GitHub"
                   text="GitHub"
                   icon={
@@ -397,7 +397,7 @@ function App() {
                 />
 
                 <ExternalLink
-                  href="https://github.com/pytorch-labs/tritonparse/wiki"
+                  href="https://github.com/meta-pytorch/tritonparse/wiki"
                   title="View Wiki"
                   text="Wiki"
                   icon={


### PR DESCRIPTION
## Summary

This pull request updates the project's URLs and references to reflect its new location under the `meta-pytorch` organization, and includes minor improvements and maintenance.

### Changes

- Updated all repository, documentation, and GitHub Pages links from `pytorch-labs` to `meta-pytorch` in:
  - `README.md`
  - `pyproject.toml`
  - `.github/workflows/test.yml`
  - `tritonparse/tools/decompress_bin_ndjson.py`
  - `website/src/App.tsx`
- Updated `git clone`、`pip install`、GitHub Pages、Issues、Discussions links
- Added `.github/copilot-instructions.md` to provide project context for AI assistants.
- Minor `.gitignore` update（add `*.mdc`）。
- Minor formatting and comment corrections (e.g., in `decompress_bin_ndjson.py`).
