### PR TITLE
Add output preservation option in test cleanup logic

### DIFF
--- a/tests/test_tritonparse.py
+++ b/tests/test_tritonparse.py
@@ -34,6 +34,14 @@ from triton.knobs import CompileTimes
 from tritonparse.structured_logging import convert, extract_python_source_info
 
 
+def should_keep_output() -> bool:
+    """Return True if test outputs (e.g., temp dirs) should be preserved.
+
+    Controlled by environment variable TEST_KEEP_OUTPUT=1.
+    """
+    return os.environ.get("TEST_KEEP_OUTPUT") == "1"
+
+
 class TestTritonparseCPU(unittest.TestCase):
     """CPU-only tests (no CUDA required)"""
 
@@ -286,8 +294,13 @@ class TestTritonparseCUDA(unittest.TestCase):
             assert len(parsed_files) > 0, "No files found in parsed output directory"
         finally:
             # Clean up
-            shutil.rmtree(temp_dir)
-            print("✓ Cleaned up temporary directory")
+            if should_keep_output():
+                print(
+                    f"✓ Preserving temporary directory (TEST_KEEP_OUTPUT=1): {temp_dir}"
+                )
+            else:
+                shutil.rmtree(temp_dir)
+                print("✓ Cleaned up temporary directory")
             tritonparse.structured_logging.clear_logging_config()
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
@@ -589,8 +602,13 @@ class TestTritonparseCUDA(unittest.TestCase):
 
         finally:
             # Clean up
-            shutil.rmtree(temp_dir)
-            print("✓ Cleaned up temporary directory")
+            if should_keep_output():
+                print(
+                    f"✓ Preserving temporary directory (TEST_KEEP_OUTPUT=1): {temp_dir}"
+                )
+            else:
+                shutil.rmtree(temp_dir)
+                print("✓ Cleaned up temporary directory")
             tritonparse.structured_logging.clear_logging_config()
 
 


### PR DESCRIPTION
Summary:
This commit introduces a new function, `should_keep_output`, which checks the environment variable `TEST_KEEP_OUTPUT`. If set to `1`, temporary directories created during tests will be preserved instead of deleted. This enhancement allows for easier debugging by retaining test outputs when needed.

Key Changes:
- Added `should_keep_output` function to determine if outputs should be kept.
- Updated cleanup logic in `TestTritonparseCUDA` to conditionally preserve or delete temporary directories based on the environment variable.

This change improves the testing experience by providing flexibility in managing test artifacts.