### PR TITLE
Add `init_with_env` function for environment-based initialization

### DIFF
--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -1013,6 +1013,15 @@ def init(trace_folder: Optional[str] = None, enable_trace_launch: bool = False):
     knobs.compilation.listener = maybe_trace_triton
 
 
+def init_with_env():
+    """
+    This function is used to initialize TritonParse with the environment variable TRITON_TRACE_FOLDER and TRITON_TRACE_LAUNCH specifically.
+    It is only supposed to be used in OSS triton's source code.
+    """
+    if triton_trace_folder:
+        init(triton_trace_folder, enable_trace_launch=TRITON_TRACE_LAUNCH)
+
+
 def clear_logging_config():
     """
     Clear all configurations made by init() and init_basic().


### PR DESCRIPTION
Summary:
This commit introduces a new function, `init_with_env`, which initializes TritonParse using the environment variables `TRITON_TRACE_FOLDER` and `TRITON_TRACE_LAUNCH`. This function is intended for use specifically within OSS Triton's source code.

Changes:
- Added `init_with_env` function to facilitate environment-based initialization.

Testing/Verification:
1. Ensure the environment variables are set correctly.
2. Call `init_with_env` and verify that it initializes with the expected parameters.

This enhancement improves the flexibility of the initialization process for users working with environment configurations.