### PR TITLE
Enable setuptools-scm and nightly PyPI publishing

### DIFF
--- a/.github/workflows/nightly-pypi.yml
+++ b/.github/workflows/nightly-pypi.yml
@@ -1,0 +1,53 @@
+name: Nightly PyPI Publish (API Token)
+
+on:
+  schedule:
+    - cron: "8 7 * * *"   # 07:08 UTC daily
+  workflow_dispatch: {}     # allow manual runs (no publish)
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0      # setuptools-scm requires full history/tags
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build setuptools-scm
+
+      - name: Compute nightly version from latest tag (per-second)
+        id: ver
+        run: |
+          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.1.0)
+          BASE=${TAG#v}
+          DATE=$(date -u +%Y%m%d%H%M%S)
+          echo "NVER=${BASE}.dev${DATE}" >> $GITHUB_OUTPUT
+
+      - name: Build sdist/wheel with forced version
+        run: |
+          export SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.ver.outputs.NVER }}
+          python -m build
+
+      - name: Check metadata
+        run: |
+          pip install twine
+          twine check dist/*
+
+      - name: Publish to PyPI (API token)
+        if: github.event_name == 'schedule' && secrets.PYPI_API_TOKEN != ''
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/.github/workflows/nightly-pypi.yml
+++ b/.github/workflows/nightly-pypi.yml
@@ -1,5 +1,4 @@
-name: Nightly PyPI Publish (API Token)
-
+name: Nightly PyPI Publish
 on:
   schedule:
     - cron: "8 7 * * *"   # 07:08 UTC daily

--- a/.github/workflows/nightly-pypi.yml
+++ b/.github/workflows/nightly-pypi.yml
@@ -45,7 +45,7 @@ jobs:
           twine check dist/*
 
       - name: Publish to PyPI (API token)
-        if: github.event_name == 'schedule' && secrets.PYPI_API_TOKEN != ''
+        if: github.event_name == 'schedule'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,24 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "tritonparse"
-version = "0.1.1"
+dynamic = ["version"]
 dependencies = [
     "triton>3.3.1",
 ]
 requires-python = ">=3.10"
-
+description = "TritonParse: A Compiler Tracer, Visualizer, and mini-Reproducer Generator for Triton Kernels"
+readme = "README.md"
 [project.optional-dependencies]
 test = [
     "coverage>=7.0.0",
 ]
+authors = [
+    { name="Yueming Hao", email="yhao@meta.com" },
+]
+license = { text = "BSD-3-Clause" }
 
 
 [tool.setuptools.packages.find]
@@ -29,6 +34,10 @@ sorter = "usort"
 
 [tool.usort]
 first_party_detection = false
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
 
 [project.urls]
 "Homepage" = "https://github.com/meta-pytorch/tritonparse"


### PR DESCRIPTION
fix https://github.com/meta-pytorch/tritonparse/issues/94
### Summary
- Adopt setuptools-scm dynamic versioning (remove hardcoded version).
- Add a nightly PyPI publish workflow that generates PEP 440–compliant dev versions from the latest tag with per-second UTC timestamps: `X.Y.Z.devYYYYMMDDHHMMSS`.
- Publish to PyPI only on scheduled runs; manual runs build and validate but do not publish.

### Changes vs main
- Added: `.github/workflows/nightly-pypi.yml`
  - Checkout with full history/tags.
  - Install build tooling (`build`, `setuptools-scm`).
  - Compute version from the latest tag via shell and per-second UTC time.
  - Force version using `SETUPTOOLS_SCM_PRETEND_VERSION` and build sdist/wheel.
  - Validate metadata with `twine check`.
  - Publish only when triggered by `schedule`.
- Modified: `pyproject.toml`
  - Remove `version = "..."`; add `dynamic = ["version"]`.
  - Bump `setuptools` minimum to `>=64` to support PEP 621 dynamic versioning.
  - Keep `setuptools_scm` config: `version_scheme = "guess-next-dev"`, `local_scheme = "no-local-version"`.

### Rationale
- Ensure PyPI-acceptable versions (no local part like `+g<sha>`; strict PEP 440).
- Avoid manual base-version maintenance; derive from Git tags.
- Guarantee unique nightly builds even with multiple runs on the same day.

### How to verify
- Local (no publish):
  1) `git fetch --tags`
  2) `python -m venv .venv && source .venv/bin/activate`
  3) `pip install -U pip && pip install build setuptools-scm twine`
  4) `TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.1.0); BASE=${TAG#v}; DATE=$(date -u +%Y%m%d%H%M%S); export SETUPTOOLS_SCM_PRETEND_VERSION=${BASE}.dev${DATE}`
  5) `python -m build && twine check dist/*`
- GitHub Actions:
  - After this workflow exists on the default branch, use “Run workflow” (manual run does not publish) or wait for the next cron to publish (requires `PYPI_API_TOKEN`).

### Impact
- No breaking changes to consumers. Release tags (e.g., `v0.1.1`) continue to produce stable versions.

### Secrets / Configuration
- Repository secret `PYPI_API_TOKEN` is required for scheduled publishes.
