### PR TITLE
Add tagged PyPI release publishing

### DIFF
--- a/.github/workflows/nightly-pypi.yml
+++ b/.github/workflows/nightly-pypi.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "8 7 * * *"   # 07:08 UTC daily
   workflow_dispatch: {}     # allow manual runs (no publish)
+  push:
+    tags:
+      - "v*"
+      - "*.*.*"
 
 permissions:
   contents: read
@@ -27,15 +31,18 @@ jobs:
 
       - name: Compute nightly version from latest tag (per-second)
         id: ver
+        if: github.ref_type != 'tag'
         run: |
           TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.1.0)
           BASE=${TAG#v}
           DATE=$(date -u +%Y%m%d%H%M%S)
           echo "NVER=${BASE}.dev${DATE}" >> $GITHUB_OUTPUT
 
-      - name: Build sdist/wheel with forced version
+      - name: Build sdist/wheel
         run: |
-          export SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.ver.outputs.NVER }}
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            export SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.ver.outputs.NVER }}
+          fi
           python -m build
 
       - name: Check metadata
@@ -44,7 +51,7 @@ jobs:
           twine check dist/*
 
       - name: Publish to PyPI (API token)
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || github.ref_type == 'tag'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION

### Summary
- Enable publishing stable releases to PyPI when pushing version tags.

### Changes
- `.github/workflows/nightly-pypi.yml`
  - Add `push` triggers for version tags: `v*` and `*.*.*`.
  - Skip nightly version computation on tag events: `if: github.ref_type != 'tag'`.
  - Build step sets `SETUPTOOLS_SCM_PRETEND_VERSION` only for non-tag events; tagged builds derive version from the tag via setuptools-scm.
  - Publish step runs on schedule (nightly) or when `ref_type == 'tag'` (stable release).

### Behavior
- Tag push (e.g., `v0.2.0`): produces a stable artifact with version `0.2.0` and publishes to PyPI.
- Nightly behavior is unchanged and continues to publish dev builds on schedule.

### How to verify
- Ensure `PYPI_API_TOKEN` is configured in repository secrets.
- Create and push a tag: `git tag v0.2.0 && git push origin v0.2.0`.
- Check workflow logs:
  - The nightly version computation step is skipped.
  - Built artifacts in `dist/` use the tag version (no `dev`).
  - Publish step executes for the tag event.

### Safety
- To avoid unintended publishing during tests, omit `PYPI_API_TOKEN` or test on a fork/private repo.
