### PR TITLE
Show build date (localized) and Git short SHA in footer

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -534,7 +534,14 @@ function App() {
             <a href="https://opensource.fb.com/legal/privacy" className="hover:underline">Privacy Policy</a>
           </div>
           <div className="text-gray-500">
-            Version {import.meta.env.PACKAGE_VERSION}
+            {(() => {
+              const buildDate = new Date(import.meta.env.PACKAGE_BUILD_DATE)
+              const localized = isNaN(buildDate.getTime())
+                ? import.meta.env.PACKAGE_BUILD_DATE
+                : buildDate.toLocaleString()
+              const sha = import.meta.env.GIT_COMMIT_SHA_SHORT
+              return `Version ${import.meta.env.PACKAGE_VERSION} · Built ${localized} · ${sha}`
+            })()}
           </div>
         </div>
       </footer>

--- a/website/src/vite-env.d.ts
+++ b/website/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly PACKAGE_VERSION: string;
+  readonly PACKAGE_BUILD_DATE: string;
+  readonly GIT_COMMIT_SHA_SHORT: string;
 }
 
 interface ImportMeta {

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -2,10 +2,22 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
+import { execSync } from 'child_process'
 
 const packageJson = JSON.parse(
   readFileSync(resolve(__dirname, 'package.json'), 'utf-8')
 )
+
+// Build-time metadata
+const buildDate = process.env.BUILD_DATE || new Date().toISOString()
+let gitSha = process.env.GIT_COMMIT_SHA_SHORT
+if (!gitSha) {
+  try {
+    gitSha = execSync('git rev-parse --short HEAD').toString().trim()
+  } catch {
+    gitSha = 'unknown'
+  }
+}
 
 export default defineConfig({
   plugins: [
@@ -36,6 +48,8 @@ export default defineConfig({
     }
   },
   define: {
-    'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version)
+    'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
+    'import.meta.env.PACKAGE_BUILD_DATE': JSON.stringify(buildDate),
+    'import.meta.env.GIT_COMMIT_SHA_SHORT': JSON.stringify(gitSha)
   }
 })

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -23,22 +23,22 @@ const buildDate = process.env.BUILD_DATE || new Date().toISOString()
 // Resolve a short commit SHA for build metadata.
 // Precedence:
 // 1) GIT_COMMIT_SHA_SHORT environment variable (CI can set this explicitly)
-// 2) git rev-parse --short HEAD
-// 3) hg id -i (Mercurial)
+// 2) git rev-parse --short HEAD  -> returns "git:<sha>"
+// 3) hg id -i (Mercurial)        -> returns "hg:<sha>"
 // 4) 'unknown' (neither VCS available)
 function resolveCommitSha(): string {
   const envSha = process.env.GIT_COMMIT_SHA_SHORT
   if (envSha) return envSha
 
   // Try Git first, then Mercurial.
-  const candidates = [
-    'git rev-parse --short HEAD',
-    'hg id -i'
+  const candidates: Array<{ cmd: string; prefix: string }> = [
+    { cmd: 'git rev-parse --short HEAD', prefix: 'git:' },
+    { cmd: 'hg id -i', prefix: 'hg:' }
   ]
 
-  for (const command of candidates) {
-    const out = safeExecTrim(command)
-    if (out) return out
+  for (const { cmd, prefix } of candidates) {
+    const out = safeExecTrim(cmd)
+    if (out) return `${prefix}${out}`
   }
   // Final fallback when no VCS is present or accessible.
   return 'unknown'


### PR DESCRIPTION
### Motivation
- Improve traceability of website builds by displaying:
  - the app version (from `package.json`),
  - the build timestamp (localized at runtime via `toLocaleString()`), and
  - the Git commit short SHA used for the build.

### Summary of Changes
- Inject build metadata at build time via Vite `define`:
  - `import.meta.env.PACKAGE_VERSION` (existing) → from `package.json`.
  - `import.meta.env.PACKAGE_BUILD_DATE` → ISO string from `BUILD_DATE` env or `new Date().toISOString()`.
  - `import.meta.env.GIT_COMMIT_SHA_SHORT` → from `GIT_COMMIT_SHA_SHORT` env or `git rev-parse --short HEAD`, with fallback to `"unknown"`.

- Extend TypeScript env typings (`src/vite-env.d.ts`) with the two new fields.

- Render in footer (localized date):
  - Example format: `Version 0.1.1 · Built 9/10/2025, 4:21:45 PM · git:abc1234`.

### Files Touched
- `website/vite.config.ts`
  - Injected `PACKAGE_BUILD_DATE` and `GIT_COMMIT_SHA_SHORT` into `import.meta.env` using Vite `define`.
  - Safe fallbacks: if not in a Git repo/CI without Git, value becomes `"unknown"`.

- `website/src/vite-env.d.ts`
  - Added typings for `PACKAGE_BUILD_DATE` and `GIT_COMMIT_SHA_SHORT`.

- `website/src/App.tsx`
  - Footer now shows: version, localized build date (`toLocaleString()`), and short SHA.

### Implementation Details
- Build-time values are set once when Vite starts (dev) or during `vite build` (prod):
  - Dev server must be restarted to refresh the build date/SHA.
  - `toLocaleString()` uses the user's browser locale/timezone for display.
- CI environments can optionally pass explicit values to ensure reproducible metadata:
  - `BUILD_DATE=2025-09-10T08:00:00Z`
  - `GIT_COMMIT_SHA_SHORT=abc123`
- If `git` is unavailable or the working directory is not a Git repo, SHA falls back to `"unknown"`.

### How to Test
1) Development
```bash
cd website
npm run dev
# Open the app. Footer should display:
# Version <pkgVersion> · Built <localizedDateTime> · <shortSHA or unknown>
```

2) Production build
```bash
cd website
npm run build
npm run preview
# Verify footer shows version, localized build date, and short SHA
```

3) Override via environment variables (optional)
```bash
# Dev
BUILD_DATE=2025-09-10T08:00:00Z GIT_COMMIT_SHA_SHORT=abc123 npm run dev

# Build
BUILD_DATE=2025-09-10T08:00:00Z GIT_COMMIT_SHA_SHORT=abc123 npm run build
```

### Risk/Impact
- Low. Purely presentational. No runtime network calls introduced.
- Backward-compatible: existing `PACKAGE_VERSION` use remains unchanged; new values have safe fallbacks.

### Notes for CI
- Ensure the repo is a Git checkout if you want automatic SHA detection, or provide `GIT_COMMIT_SHA_SHORT` explicitly.
- The build date defaults to the build machine time unless `BUILD_DATE` is provided.


