### PR TITLE
[File Diff] PR2: FileDiff session 

### DIFF
--- a/website/src/components/DiffComparisonView.tsx
+++ b/website/src/components/DiffComparisonView.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { DiffEditor } from "@monaco-editor/react";
+
+interface DiffOptions {
+  ignoreWhitespace?: boolean;
+  wordLevel?: boolean; // kept for future, Monaco uses its own algorithm
+  context?: number; // lines of context when hiding unchanged regions
+  wordWrap?: "off" | "on";
+  onlyChanged?: boolean;
+}
+
+interface DiffComparisonViewProps {
+  leftContent: string;
+  rightContent: string;
+  language?: string;
+  height?: string;
+  options?: DiffOptions;
+}
+
+const DiffComparisonView: React.FC<DiffComparisonViewProps> = ({
+  leftContent,
+  rightContent,
+  language = "plaintext",
+  height = "calc(100vh - 16rem)",
+  options,
+}) => {
+  const monacoOptions = useMemo(() => {
+    const hideUnchanged = options?.onlyChanged
+      ? {
+          enabled: true,
+          revealLineCount: Math.max(0, options?.context ?? 3),
+        }
+      : undefined;
+
+    const opts = {
+      readOnly: true,
+      renderSideBySide: true,
+      renderOverviewRuler: true,
+      renderIndicators: true,
+      // Enable diff-editor level word wrap (VSCode has a separate setting for this)
+      diffWordWrap: "on",
+      wordWrap: options?.wordWrap ?? "on",
+      // Force both sides to honor wrap regardless of per-side defaults
+      wordWrapOverride1: "on",
+      wordWrapOverride2: "on",
+      wordWrapMinified: true,
+      wrappingStrategy: "advanced",
+      // Ensure even original (left) honors wrapping consistently
+      originalEditable: false,
+      ignoreTrimWhitespace: options?.ignoreWhitespace ?? true,
+      // @ts-ignore - monaco types may vary by version; it's safe to pass through
+      hideUnchangedRegions: hideUnchanged,
+      // @ts-ignore - prefer advanced algorithm if available
+      diffAlgorithm: "advanced",
+      // @ts-ignore - hide horizontal scrollbar when wrapping
+      scrollbar: {
+        vertical: 'auto',
+        horizontal: 'hidden',
+        horizontalScrollbarSize: 0,
+      },
+      // keep view lean
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      automaticLayout: true,
+    } as any;
+    return opts;
+  }, [options]);
+
+  const editorRef = useRef<any>(null);
+
+  // Keep both panes in sync when options change
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    try {
+      const wrap = options?.wordWrap ?? "on";
+      const original = editor.getOriginalEditor?.();
+      const modified = editor.getModifiedEditor?.();
+      const shared = { wordWrap: wrap, wordWrapMinified: true, wrappingStrategy: 'advanced', scrollbar: { horizontal: 'hidden', horizontalScrollbarSize: 0 } } as any;
+      original?.updateOptions?.(shared);
+      modified?.updateOptions?.(shared);
+    } catch {}
+  }, [options?.wordWrap]);
+
+  // Ensure diff editor is fully disposed on unmount to avoid Monaco race conditions
+  useEffect(() => {
+    return () => {
+      try {
+        const editor: any = editorRef.current;
+        if (editor && typeof editor.dispose === 'function') {
+          editor.dispose();
+        }
+      } catch {}
+    };
+  }, []);
+
+  // Vertical resizable container: keep width 100%, allow drag to change height
+  const initialPxHeight = useMemo(() => {
+    // If a pixel value is provided, use it directly
+    if (typeof height === 'string') {
+      const pxMatch = height.match(/(\d+)px$/);
+      if (pxMatch) {
+        try { return parseInt(pxMatch[1], 10); } catch { /* ignore */ }
+      }
+
+      // Support calc(100vh - Xrem)
+      const calcRemMatch = height.match(/calc\(100vh\s*-\s*(\d+(?:\.\d+)?)rem\)/i);
+      if (calcRemMatch && typeof window !== 'undefined') {
+        const rem = parseFloat(calcRemMatch[1]);
+        const remPx = rem * 16; // assume 1rem = 16px baseline
+        return Math.max(240, Math.round(window.innerHeight - remPx));
+      }
+
+      // Support plain vh values (e.g., 80vh)
+      const vhMatch = height.match(/(\d+(?:\.\d+)?)vh/i);
+      if (vhMatch && typeof window !== 'undefined') {
+        const vh = parseFloat(vhMatch[1]);
+        return Math.max(240, Math.round(window.innerHeight * (vh / 100)));
+      }
+    }
+
+    // Fallback: viewport height minus 16rem (~256px) if available; otherwise 600px
+    if (typeof window !== 'undefined') {
+      return Math.max(240, window.innerHeight - 256);
+    }
+    return 600;
+  }, [height]);
+
+  const [containerHeight, setContainerHeight] = useState<number>(initialPxHeight);
+
+  return (
+    <div className="w-full border border-gray-200 rounded bg-white">
+      <div
+        className="w-full resize-y overflow-auto"
+        style={{ height: `${containerHeight}px`, minHeight: 240 }}
+        // Browser native resize-y changes element height; Monaco autoLayout observes size
+        onMouseUp={() => {
+          // Capture final height after drag (optional state sync)
+          try {
+            const node = (editorRef.current as any)?.getDomNode?.();
+            if (node && (node as HTMLElement).parentElement) {
+              const h = (node as HTMLElement).parentElement!.clientHeight;
+              if (h > 0) setContainerHeight(h);
+            }
+          } catch {}
+        }}
+      >
+      <DiffEditor
+        height="100%"
+        language={language === "python" ? "python" : "plaintext"}
+        original={leftContent ?? ""}
+        modified={rightContent ?? ""}
+        options={monacoOptions}
+        theme="light"
+        // Ensure both panes use the same wrapping and scrollbar behavior
+        onMount={(editor: any) => {
+          try {
+            // Expose for optional console debugging
+            (window as any).__DIFF = editor;
+            editorRef.current = editor;
+
+            const applyWrap = (_when: string) => {
+              try {
+                const wrap = options?.wordWrap ?? "on";
+                const original = editor.getOriginalEditor?.();
+                const modified = editor.getModifiedEditor?.();
+                const shared = { wordWrap: wrap, wordWrapMinified: true, wrappingStrategy: 'advanced', wrappingIndent: 'same', scrollbar: { horizontal: 'hidden', horizontalScrollbarSize: 0 } } as any;
+                original?.updateOptions?.(shared);
+                modified?.updateOptions?.(shared);
+                // Force layout after changing wrap
+                try { original?.layout?.(); } catch {}
+                try { modified?.layout?.(); } catch {}
+              } catch (e) {
+                // swallow errors
+              }
+            };
+
+            // Apply at several timing points to avoid initialization overwrites
+            applyWrap('onMount immediate');
+            requestAnimationFrame(() => applyWrap('onMount rAF'));
+            setTimeout(() => applyWrap('onMount t=0'), 0);
+            setTimeout(() => applyWrap('onMount t=100'), 100);
+            setTimeout(() => applyWrap('onMount t=300'), 300);
+
+            // Re-apply on diff/layout/model changes
+            try { editor.onDidUpdateDiff?.(() => applyWrap('onDidUpdateDiff')); } catch {}
+            try { editor.getOriginalEditor?.()?.onDidLayoutChange?.(() => applyWrap('original onDidLayoutChange')); } catch {}
+            try { editor.getModifiedEditor?.()?.onDidLayoutChange?.(() => applyWrap('modified onDidLayoutChange')); } catch {}
+            try { editor.getOriginalEditor?.()?.onDidChangeModel?.(() => applyWrap('original onDidChangeModel')); } catch {}
+            try { editor.getModifiedEditor?.()?.onDidChangeModel?.(() => applyWrap('modified onDidChangeModel')); } catch {}
+          } catch (e) {
+            // swallow errors
+          }
+        }}
+        loading={<div className="p-4 text-gray-600">Loading diff viewer...</div>}
+      />
+      </div>
+    </div>
+  );
+};
+
+export default DiffComparisonView;
+
+

--- a/website/src/context/FileDiffSession.tsx
+++ b/website/src/context/FileDiffSession.tsx
@@ -1,0 +1,132 @@
+import React, { createContext, useContext, useMemo, useRef, useState } from "react";
+import type { ProcessedKernel } from "../utils/dataLoader";
+
+type SourceType = 'url' | 'local' | null;
+
+interface SideState {
+  sourceType: SourceType;
+  url: string | null;
+  kernels: ProcessedKernel[];
+  selectedIdx: number;
+}
+
+interface DiffOptionsState {
+  mode: 'single' | 'all';
+  irType: string;
+  ignoreWs: boolean;
+  wordLevel: boolean;
+  contextLines: number;
+  wordWrap: 'off' | 'on';
+  onlyChanged: boolean;
+}
+
+interface AppControls {
+  setKernels?: (k: ProcessedKernel[]) => void;
+  setLoadedUrl?: (u: string | null) => void;
+  setActiveTab?: (t: string) => void;
+  setSelectedKernel?: (i: number) => void;
+  setDataLoaded?: (b: boolean) => void;
+}
+
+interface PreviewState {
+  active: boolean;
+  side: 'left' | 'right' | null;
+  view: 'overview' | 'ir' | null;
+}
+
+interface FileDiffSessionApi {
+  left: SideState;
+  right: SideState;
+  options: DiffOptionsState;
+  preview: PreviewState;
+  setLeftFromUrl: (url: string, kernels: ProcessedKernel[]) => void;
+  setLeftFromLocal: (kernels: ProcessedKernel[]) => void;
+  setRightFromUrl: (url: string, kernels: ProcessedKernel[]) => void;
+  setRightFromLocal: (kernels: ProcessedKernel[]) => void;
+  setLeftIdx: (idx: number) => void;
+  setRightIdx: (idx: number) => void;
+  setOptions: (partial: Partial<DiffOptionsState>) => void;
+  reset: () => void;
+  registerAppControls: (ctrls: AppControls) => void;
+  setPreview: (p: PreviewState) => void;
+  clearPreview: () => void;
+  gotoOverview: (side: 'left' | 'right') => void;
+  gotoIRCode: (side: 'left' | 'right') => void;
+}
+
+const defaultSide: SideState = { sourceType: null, url: null, kernels: [], selectedIdx: 0 };
+
+const defaultOptions: DiffOptionsState = {
+  mode: 'single',
+  irType: 'ttgir',
+  ignoreWs: true,
+  wordLevel: true,
+  contextLines: 3,
+  wordWrap: 'on',
+  onlyChanged: false,
+};
+
+const FileDiffSessionContext = createContext<FileDiffSessionApi | null>(null);
+
+export const FileDiffSessionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [left, setLeft] = useState<SideState>(defaultSide);
+  const [right, setRight] = useState<SideState>(defaultSide);
+  const [options, setOptionsState] = useState<DiffOptionsState>(defaultOptions);
+  const [preview, setPreviewState] = useState<PreviewState>({ active: false, side: null, view: null });
+
+  const appControlsRef = useRef<AppControls>({});
+
+  const api: FileDiffSessionApi = useMemo(() => ({
+    left,
+    right,
+    options,
+    preview,
+    setLeftFromUrl: (url, kernels) => setLeft({ sourceType: 'url', url, kernels, selectedIdx: 0 }),
+    setLeftFromLocal: (kernels) => setLeft({ sourceType: 'local', url: null, kernels, selectedIdx: 0 }),
+    setRightFromUrl: (url, kernels) => setRight({ sourceType: 'url', url, kernels, selectedIdx: 0 }),
+    setRightFromLocal: (kernels) => setRight({ sourceType: 'local', url: null, kernels, selectedIdx: 0 }),
+    setLeftIdx: (idx) => setLeft(prev => ({ ...prev, selectedIdx: idx })),
+    setRightIdx: (idx) => setRight(prev => ({ ...prev, selectedIdx: idx })),
+    setOptions: (partial) => setOptionsState(prev => ({ ...prev, ...partial })),
+    reset: () => { setLeft(defaultSide); setRight(defaultSide); setOptionsState(defaultOptions); setPreviewState({ active: false, side: null, view: null }); },
+    registerAppControls: (ctrls) => { appControlsRef.current = ctrls; },
+    setPreview: (p) => setPreviewState(p),
+    clearPreview: () => setPreviewState({ active: false, side: null, view: null }),
+    gotoOverview: (side) => {
+      const s = side === 'left' ? left : right;
+      if (!s || s.kernels.length === 0) return;
+      const { setActiveTab } = appControlsRef.current;
+      setPreviewState({ active: true, side, view: 'overview' });
+      setTimeout(() => {
+        setActiveTab?.('overview');
+        const newUrl = new URL(window.location.href);
+        newUrl.searchParams.delete('view');
+        window.history.replaceState({}, '', newUrl.toString());
+      }, 0);
+    },
+    gotoIRCode: (side) => {
+      const s = side === 'left' ? left : right;
+      if (!s || s.kernels.length === 0) return;
+      const { setActiveTab } = appControlsRef.current;
+      setPreviewState({ active: true, side, view: 'ir' });
+      setTimeout(() => {
+        setActiveTab?.('comparison');
+        const newUrl = new URL(window.location.href);
+        newUrl.searchParams.set('view', 'ir_code_comparison');
+        window.history.replaceState({}, '', newUrl.toString());
+      }, 0);
+    },
+  }), [left, right, options, preview]);
+
+  return (
+    <FileDiffSessionContext.Provider value={api}>{children}</FileDiffSessionContext.Provider>
+  );
+};
+
+export const useFileDiffSession = (): FileDiffSessionApi => {
+  const ctx = useContext(FileDiffSessionContext);
+  if (!ctx) throw new Error('useFileDiffSession must be used within FileDiffSessionProvider');
+  return ctx;
+};
+
+

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { FileDiffSessionProvider } from './context/FileDiffSession.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <FileDiffSessionProvider>
+      <App />
+    </FileDiffSessionProvider>
   </StrictMode>,
 )


### PR DESCRIPTION

#### Summary
- Adds `FileDiffSession` React context/provider as a single source of truth for File Diff state.
- Tracks left/right sources, selected kernel indices, diff options, and preview state for cross-view navigation.

#### Key Changes
- New file: `website/src/context/FileDiffSession.tsx` exposing APIs to set sources from URL/local, update selections, and set diff options.
- Adds preview navigation helpers `gotoOverview` and `gotoIRCode` with deferred tab switching to avoid Monaco unmount races.
- Provides `clearPreview` and registration of App controls to coordinate navigation without mutating App global data.

