### PR TITLE
[File Diff] PR6: Add Monaco editor

### DIFF
--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -346,17 +346,29 @@ function App() {
         </div>
       );
     } else {
-      // Show either overview or code comparison based on active tab
-      return activeTab === "overview" ? (
-        <KernelOverview
-          kernels={kernels}
-          onViewIR={handleViewSingleIR}
-          selectedKernel={selectedKernel}
-          onSelectKernel={handleSelectKernel}
-        />
-      ) : (
-        <CodeView kernels={kernels} selectedKernel={selectedKernel} />
-      );
+      // Show either overview, IR code, or file diff based on active tab
+      if (activeTab === "overview") {
+        return (
+          <KernelOverview
+            kernels={kernels}
+            onViewIR={handleViewSingleIR}
+            selectedKernel={selectedKernel}
+            onSelectKernel={handleSelectKernel}
+          />
+        );
+      }
+      if (activeTab === "comparison") {
+        return <CodeView kernels={kernels} selectedKernel={selectedKernel} />;
+      }
+      if (activeTab === "file_diff") {
+        return (
+          <div className="p-6 text-gray-700">
+            <div className="text-lg font-semibold mb-2">File Diff</div>
+            <div>This view is available. Detailed functionality will be introduced in subsequent changes.</div>
+          </div>
+        );
+      }
+      return null;
     }
   };
 
@@ -430,45 +442,57 @@ function App() {
               isLoading={loading}
             />
 
-            {/* Tab navigation (only show when data is loaded and not in IR view) */}
-            {dataLoaded && kernels.length > 0 && !selectedIR && (
-              <div className="flex space-x-4">
-                <button
-                  className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "overview" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                    }`}
-                  onClick={() => {
-                    setActiveTab("overview");
+            {/* Tab navigation: File Diff is always visible; other tabs only when data is loaded and not in IR view */}
+            <div className="flex space-x-4">
+              <button
+                className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "file_diff" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                  }`}
+                onClick={() => {
+                  setActiveTab("file_diff");
+                }}
+              >
+                File Diff
+              </button>
 
-                    // Update URL parameters when switching to overview
-                    if (loadedUrl) {
-                      const newUrl = new URL(window.location.href);
-                      // Remove view parameter but keep kernel_hash
-                      newUrl.searchParams.delete("view");
-                      window.history.replaceState({}, "", newUrl.toString());
-                    }
-                  }}
-                >
-                  Kernel Overview
-                </button>
-                <button
-                  className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "comparison" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                    }`}
-                  onClick={() => {
-                    setActiveTab("comparison");
+              {dataLoaded && kernels.length > 0 && !selectedIR && (
+                <>
+                  <button
+                    className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "overview" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                      }`}
+                    onClick={() => {
+                      setActiveTab("overview");
 
-                    // Update URL parameters when switching to comparison view
-                    if (loadedUrl) {
-                      const newUrl = new URL(window.location.href);
-                      // Add view parameter
-                      newUrl.searchParams.set("view", "ir_code_comparison");
-                      window.history.replaceState({}, "", newUrl.toString());
-                    }
-                  }}
-                >
-                  IR Code Comparison
-                </button>
-              </div>
-            )}
+                      // Update URL parameters when switching to overview
+                      if (loadedUrl) {
+                        const newUrl = new URL(window.location.href);
+                        // Remove view parameter but keep kernel_hash
+                        newUrl.searchParams.delete("view");
+                        window.history.replaceState({}, "", newUrl.toString());
+                      }
+                    }}
+                  >
+                    Kernel Overview
+                  </button>
+                  <button
+                    className={`px-3 py-2 text-sm font-medium rounded-md ${activeTab === "comparison" ? "bg-blue-700 text-white shadow-md" : "bg-blue-100 text-blue-700 hover:bg-blue-200"
+                      }`}
+                    onClick={() => {
+                      setActiveTab("comparison");
+
+                      // Update URL parameters when switching to comparison view
+                      if (loadedUrl) {
+                        const newUrl = new URL(window.location.href);
+                        // Add view parameter
+                        newUrl.searchParams.set("view", "ir_code_comparison");
+                        window.history.replaceState({}, "", newUrl.toString());
+                      }
+                    }}
+                  >
+                    IR Code
+                  </button>
+                </>
+              )}
+            </div>
           </div>
         </div>
       </header>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from "./utils/dataLoader";
 import { checkFbDirectoryExists } from "./utils/fbDetection";
 import CodeView from "./pages/CodeView";
+import FileDiffView from "./pages/FileDiffView";
 import SingleCodeViewer from "./components/SingleCodeViewer";
 import KernelOverview from "./pages/KernelOverview";
 import DataSourceSelector from "./components/DataSourceSelector";
@@ -362,10 +363,11 @@ function App() {
       }
       if (activeTab === "file_diff") {
         return (
-          <div className="p-6 text-gray-700">
-            <div className="text-lg font-semibold mb-2">File Diff</div>
-            <div>This view is available. Detailed functionality will be introduced in subsequent changes.</div>
-          </div>
+          <FileDiffView
+            kernelsLeft={kernels}
+            selectedLeftIndex={Math.max(0, selectedKernel)}
+            leftLoadedUrl={loadedUrl}
+          />
         );
       }
       return null;

--- a/website/src/components/DiffComparisonView.tsx
+++ b/website/src/components/DiffComparisonView.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { DiffEditor } from "@monaco-editor/react";
+
+interface DiffOptions {
+  ignoreWhitespace?: boolean;
+  wordLevel?: boolean; // kept for future, Monaco uses its own algorithm
+  context?: number; // lines of context when hiding unchanged regions
+  wordWrap?: "off" | "on";
+  onlyChanged?: boolean;
+}
+
+interface DiffComparisonViewProps {
+  leftContent: string;
+  rightContent: string;
+  language?: string;
+  height?: string;
+  options?: DiffOptions;
+}
+
+const DiffComparisonView: React.FC<DiffComparisonViewProps> = ({
+  leftContent,
+  rightContent,
+  language = "plaintext",
+  height = "calc(100vh - 16rem)",
+  options,
+}) => {
+  const monacoOptions = useMemo(() => {
+    const hideUnchanged = options?.onlyChanged
+      ? {
+          enabled: true,
+          revealLineCount: Math.max(0, options?.context ?? 3),
+        }
+      : undefined;
+
+    const opts = {
+      readOnly: true,
+      renderSideBySide: true,
+      renderOverviewRuler: true,
+      renderIndicators: true,
+      // Enable diff-editor level word wrap (VSCode has a separate setting for this)
+      diffWordWrap: "on",
+      wordWrap: options?.wordWrap ?? "on",
+      // Force both sides to honor wrap regardless of per-side defaults
+      wordWrapOverride1: "on",
+      wordWrapOverride2: "on",
+      wordWrapMinified: true,
+      wrappingStrategy: "advanced",
+      // Ensure even original (left) honors wrapping consistently
+      originalEditable: false,
+      ignoreTrimWhitespace: options?.ignoreWhitespace ?? true,
+      // @ts-ignore - monaco types may vary by version; it's safe to pass through
+      hideUnchangedRegions: hideUnchanged,
+      // @ts-ignore - prefer advanced algorithm if available
+      diffAlgorithm: "advanced",
+      // @ts-ignore - hide horizontal scrollbar when wrapping
+      scrollbar: {
+        vertical: 'auto',
+        horizontal: 'hidden',
+        horizontalScrollbarSize: 0,
+      },
+      // keep view lean
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      automaticLayout: true,
+    } as any;
+    return opts;
+  }, [options]);
+
+  const editorRef = useRef<any>(null);
+
+  // Keep both panes in sync when options change
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    try {
+      const wrap = options?.wordWrap ?? "on";
+      const original = editor.getOriginalEditor?.();
+      const modified = editor.getModifiedEditor?.();
+      const shared = { wordWrap: wrap, wordWrapMinified: true, wrappingStrategy: 'advanced', scrollbar: { horizontal: 'hidden', horizontalScrollbarSize: 0 } } as any;
+      original?.updateOptions?.(shared);
+      modified?.updateOptions?.(shared);
+    } catch {}
+  }, [options?.wordWrap]);
+
+  // Ensure diff editor is fully disposed on unmount to avoid Monaco race conditions
+  useEffect(() => {
+    return () => {
+      try {
+        const editor: any = editorRef.current;
+        if (editor && typeof editor.dispose === 'function') {
+          editor.dispose();
+        }
+      } catch {}
+    };
+  }, []);
+
+  // Vertical resizable container: keep width 100%, allow drag to change height
+  const initialPxHeight = useMemo(() => {
+    // If a pixel value is provided, use it directly
+    if (typeof height === 'string') {
+      const pxMatch = height.match(/(\d+)px$/);
+      if (pxMatch) {
+        try { return parseInt(pxMatch[1], 10); } catch { /* ignore */ }
+      }
+
+      // Support calc(100vh - Xrem)
+      const calcRemMatch = height.match(/calc\(100vh\s*-\s*(\d+(?:\.\d+)?)rem\)/i);
+      if (calcRemMatch && typeof window !== 'undefined') {
+        const rem = parseFloat(calcRemMatch[1]);
+        const remPx = rem * 16; // assume 1rem = 16px baseline
+        return Math.max(240, Math.round(window.innerHeight - remPx));
+      }
+
+      // Support plain vh values (e.g., 80vh)
+      const vhMatch = height.match(/(\d+(?:\.\d+)?)vh/i);
+      if (vhMatch && typeof window !== 'undefined') {
+        const vh = parseFloat(vhMatch[1]);
+        return Math.max(240, Math.round(window.innerHeight * (vh / 100)));
+      }
+    }
+
+    // Fallback: viewport height minus 16rem (~256px) if available; otherwise 600px
+    if (typeof window !== 'undefined') {
+      return Math.max(240, window.innerHeight - 256);
+    }
+    return 600;
+  }, [height]);
+
+  const [containerHeight, setContainerHeight] = useState<number>(initialPxHeight);
+
+  return (
+    <div className="w-full border border-gray-200 rounded bg-white">
+      <div
+        className="w-full resize-y overflow-auto"
+        style={{ height: `${containerHeight}px`, minHeight: 240 }}
+        // Browser native resize-y changes element height; Monaco autoLayout observes size
+        onMouseUp={() => {
+          // Capture final height after drag (optional state sync)
+          try {
+            const node = (editorRef.current as any)?.getDomNode?.();
+            if (node && (node as HTMLElement).parentElement) {
+              const h = (node as HTMLElement).parentElement!.clientHeight;
+              if (h > 0) setContainerHeight(h);
+            }
+          } catch {}
+        }}
+      >
+      <DiffEditor
+        height="100%"
+        language={language === "python" ? "python" : "plaintext"}
+        original={leftContent ?? ""}
+        modified={rightContent ?? ""}
+        options={monacoOptions}
+        theme="light"
+        // Ensure both panes use the same wrapping and scrollbar behavior
+        onMount={(editor: any) => {
+          try {
+            // Expose for optional console debugging
+            (window as any).__DIFF = editor;
+            editorRef.current = editor;
+
+            const applyWrap = (_when: string) => {
+              try {
+                const wrap = options?.wordWrap ?? "on";
+                const original = editor.getOriginalEditor?.();
+                const modified = editor.getModifiedEditor?.();
+                const shared = { wordWrap: wrap, wordWrapMinified: true, wrappingStrategy: 'advanced', wrappingIndent: 'same', scrollbar: { horizontal: 'hidden', horizontalScrollbarSize: 0 } } as any;
+                original?.updateOptions?.(shared);
+                modified?.updateOptions?.(shared);
+                // Force layout after changing wrap
+                try { original?.layout?.(); } catch {}
+                try { modified?.layout?.(); } catch {}
+              } catch (e) {
+                // swallow errors
+              }
+            };
+
+            // Apply at several timing points to avoid initialization overwrites
+            applyWrap('onMount immediate');
+            requestAnimationFrame(() => applyWrap('onMount rAF'));
+            setTimeout(() => applyWrap('onMount t=0'), 0);
+            setTimeout(() => applyWrap('onMount t=100'), 100);
+            setTimeout(() => applyWrap('onMount t=300'), 300);
+
+            // Re-apply on diff/layout/model changes
+            try { editor.onDidUpdateDiff?.(() => applyWrap('onDidUpdateDiff')); } catch {}
+            try { editor.getOriginalEditor?.()?.onDidLayoutChange?.(() => applyWrap('original onDidLayoutChange')); } catch {}
+            try { editor.getModifiedEditor?.()?.onDidLayoutChange?.(() => applyWrap('modified onDidLayoutChange')); } catch {}
+            try { editor.getOriginalEditor?.()?.onDidChangeModel?.(() => applyWrap('original onDidChangeModel')); } catch {}
+            try { editor.getModifiedEditor?.()?.onDidChangeModel?.(() => applyWrap('modified onDidChangeModel')); } catch {}
+          } catch (e) {
+            // swallow errors
+          }
+        }}
+        loading={<div className="p-4 text-gray-600">Loading diff viewer...</div>}
+      />
+      </div>
+    </div>
+  );
+};
+
+export default DiffComparisonView;
+
+

--- a/website/src/components/DiffComparisonView.tsx
+++ b/website/src/components/DiffComparisonView.tsx
@@ -87,10 +87,15 @@ const DiffComparisonView: React.FC<DiffComparisonViewProps> = ({
     return () => {
       try {
         const editor: any = editorRef.current;
-        if (editor && typeof editor.dispose === 'function') {
-          editor.dispose();
+        if (editor) {
+          try { editor.setModel?.(null); } catch {}
+          try { editor.getOriginalEditor?.()?.setModel?.(null); } catch {}
+          try { editor.getModifiedEditor?.()?.setModel?.(null); } catch {}
+          try { editor.dispose?.(); } catch {}
         }
       } catch {}
+      editorRef.current = null as any;
+      try { (window as any).__DIFF = undefined; } catch {}
     };
   }, []);
 

--- a/website/src/context/FileDiffSession.tsx
+++ b/website/src/context/FileDiffSession.tsx
@@ -1,0 +1,132 @@
+import React, { createContext, useContext, useMemo, useRef, useState } from "react";
+import type { ProcessedKernel } from "../utils/dataLoader";
+
+type SourceType = 'url' | 'local' | null;
+
+interface SideState {
+  sourceType: SourceType;
+  url: string | null;
+  kernels: ProcessedKernel[];
+  selectedIdx: number;
+}
+
+interface DiffOptionsState {
+  mode: 'single' | 'all';
+  irType: string;
+  ignoreWs: boolean;
+  wordLevel: boolean;
+  contextLines: number;
+  wordWrap: 'off' | 'on';
+  onlyChanged: boolean;
+}
+
+interface AppControls {
+  setKernels?: (k: ProcessedKernel[]) => void;
+  setLoadedUrl?: (u: string | null) => void;
+  setActiveTab?: (t: string) => void;
+  setSelectedKernel?: (i: number) => void;
+  setDataLoaded?: (b: boolean) => void;
+}
+
+interface PreviewState {
+  active: boolean;
+  side: 'left' | 'right' | null;
+  view: 'overview' | 'ir' | null;
+}
+
+interface FileDiffSessionApi {
+  left: SideState;
+  right: SideState;
+  options: DiffOptionsState;
+  preview: PreviewState;
+  setLeftFromUrl: (url: string, kernels: ProcessedKernel[]) => void;
+  setLeftFromLocal: (kernels: ProcessedKernel[]) => void;
+  setRightFromUrl: (url: string, kernels: ProcessedKernel[]) => void;
+  setRightFromLocal: (kernels: ProcessedKernel[]) => void;
+  setLeftIdx: (idx: number) => void;
+  setRightIdx: (idx: number) => void;
+  setOptions: (partial: Partial<DiffOptionsState>) => void;
+  reset: () => void;
+  registerAppControls: (ctrls: AppControls) => void;
+  setPreview: (p: PreviewState) => void;
+  clearPreview: () => void;
+  gotoOverview: (side: 'left' | 'right') => void;
+  gotoIRCode: (side: 'left' | 'right') => void;
+}
+
+const defaultSide: SideState = { sourceType: null, url: null, kernels: [], selectedIdx: 0 };
+
+const defaultOptions: DiffOptionsState = {
+  mode: 'single',
+  irType: 'ttgir',
+  ignoreWs: true,
+  wordLevel: true,
+  contextLines: 3,
+  wordWrap: 'on',
+  onlyChanged: false,
+};
+
+const FileDiffSessionContext = createContext<FileDiffSessionApi | null>(null);
+
+export const FileDiffSessionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [left, setLeft] = useState<SideState>(defaultSide);
+  const [right, setRight] = useState<SideState>(defaultSide);
+  const [options, setOptionsState] = useState<DiffOptionsState>(defaultOptions);
+  const [preview, setPreviewState] = useState<PreviewState>({ active: false, side: null, view: null });
+
+  const appControlsRef = useRef<AppControls>({});
+
+  const api: FileDiffSessionApi = useMemo(() => ({
+    left,
+    right,
+    options,
+    preview,
+    setLeftFromUrl: (url, kernels) => setLeft({ sourceType: 'url', url, kernels, selectedIdx: 0 }),
+    setLeftFromLocal: (kernels) => setLeft({ sourceType: 'local', url: null, kernels, selectedIdx: 0 }),
+    setRightFromUrl: (url, kernels) => setRight({ sourceType: 'url', url, kernels, selectedIdx: 0 }),
+    setRightFromLocal: (kernels) => setRight({ sourceType: 'local', url: null, kernels, selectedIdx: 0 }),
+    setLeftIdx: (idx) => setLeft(prev => ({ ...prev, selectedIdx: idx })),
+    setRightIdx: (idx) => setRight(prev => ({ ...prev, selectedIdx: idx })),
+    setOptions: (partial) => setOptionsState(prev => ({ ...prev, ...partial })),
+    reset: () => { setLeft(defaultSide); setRight(defaultSide); setOptionsState(defaultOptions); setPreviewState({ active: false, side: null, view: null }); },
+    registerAppControls: (ctrls) => { appControlsRef.current = ctrls; },
+    setPreview: (p) => setPreviewState(p),
+    clearPreview: () => setPreviewState({ active: false, side: null, view: null }),
+    gotoOverview: (side) => {
+      const s = side === 'left' ? left : right;
+      if (!s || s.kernels.length === 0) return;
+      const { setActiveTab } = appControlsRef.current;
+      setPreviewState({ active: true, side, view: 'overview' });
+      setTimeout(() => {
+        setActiveTab?.('overview');
+        const newUrl = new URL(window.location.href);
+        newUrl.searchParams.delete('view');
+        window.history.replaceState({}, '', newUrl.toString());
+      }, 0);
+    },
+    gotoIRCode: (side) => {
+      const s = side === 'left' ? left : right;
+      if (!s || s.kernels.length === 0) return;
+      const { setActiveTab } = appControlsRef.current;
+      setPreviewState({ active: true, side, view: 'ir' });
+      setTimeout(() => {
+        setActiveTab?.('comparison');
+        const newUrl = new URL(window.location.href);
+        newUrl.searchParams.set('view', 'ir_code_comparison');
+        window.history.replaceState({}, '', newUrl.toString());
+      }, 0);
+    },
+  }), [left, right, options, preview]);
+
+  return (
+    <FileDiffSessionContext.Provider value={api}>{children}</FileDiffSessionContext.Provider>
+  );
+};
+
+export const useFileDiffSession = (): FileDiffSessionApi => {
+  const ctx = useContext(FileDiffSessionContext);
+  if (!ctx) throw new Error('useFileDiffSession must be used within FileDiffSessionProvider');
+  return ctx;
+};
+
+

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { FileDiffSessionProvider } from './context/FileDiffSession.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <FileDiffSessionProvider>
+      <App />
+    </FileDiffSessionProvider>
   </StrictMode>,
 )

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -305,6 +305,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
         </div>
         {!hideDiff && (
           <DiffComparisonView
+            key={`single-${leftIdx}-${rightIdx}-${irType}`}
             leftContent={leftContent}
             rightContent={rightContent}
             height="calc(100vh - 14rem)"
@@ -350,6 +351,7 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
                 <div className="px-2 pb-2">
                   {!hideDiff && (
                     <DiffComparisonView
+                      key={`all-${t}-${leftIdx}-${rightIdx}`}
                       leftContent={leftContent}
                       rightContent={rightContent}
                       height="calc(100vh - 14rem)"

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -1,0 +1,645 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import DiffComparisonView from "../components/DiffComparisonView";
+import { useFileDiffSession } from "../context/FileDiffSession";
+import { ProcessedKernel, loadLogData, loadLogDataFromFile, processKernelData, getIRType } from "../utils/dataLoader";
+
+type DiffMode = "single" | "all";
+
+interface FileDiffViewProps {
+  kernelsLeft: ProcessedKernel[];
+  selectedLeftIndex: number;
+  leftLoadedUrl: string | null;
+}
+
+const PARAM_VIEW = "view";
+const PARAM_JSON_B_URL = "json_b_url";
+const PARAM_KERNEL_HASH_A = "kernel_hash_a";
+const PARAM_KERNEL_HASH_B = "kernel_hash_b";
+const PARAM_MODE = "mode";
+const PARAM_IR = "ir";
+const PARAM_IGNORE_WS = "ignore_ws";
+const PARAM_WORD_LEVEL = "word_level";
+const PARAM_CONTEXT = "context";
+const PARAM_WRAP = "wrap";
+const PARAM_ONLY_CHANGED = "only_changed";
+
+function findKernelIndexByHash(hash: string | null, kernels: ProcessedKernel[]): number {
+  if (!hash) return -1;
+  const idx = kernels.findIndex(k => k.metadata?.hash === hash);
+  return idx >= 0 ? idx : -1;
+}
+
+function listIRTypesForKernel(kernel: ProcessedKernel | undefined): Set<string> {
+  const s = new Set<string>();
+  if (!kernel) return s;
+  for (const key of Object.keys(kernel.irFiles || {})) {
+    s.add(getIRType(key));
+  }
+  if (kernel.pythonSourceInfo?.code) s.add("python");
+  return s;
+}
+
+function getContentByIRType(kernel: ProcessedKernel | undefined, irType: string): string {
+  if (!kernel) return "";
+  if (irType === "python") {
+    return kernel.pythonSourceInfo?.code || "";
+  }
+  const keys = Object.keys(kernel.irFiles || {});
+  const found = keys.find(k => getIRType(k) === irType);
+  return found ? kernel.irFiles[found] : "";
+}
+
+const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIndex, leftLoadedUrl }) => {
+  const sess = useFileDiffSession();
+  // Left source state (URL/local) – overrides props when present
+  const [leftKernelsFromUrl, setLeftKernelsFromUrl] = useState<ProcessedKernel[]>([]);
+  const [leftKernelsFromLocal, setLeftKernelsFromLocal] = useState<ProcessedKernel[]>([]);
+  const [leftLoadedUrlLocal, setLeftLoadedUrlLocal] = useState<string | null>(null);
+  const [leftLoadedFromLocal, setLeftLoadedFromLocal] = useState<boolean>(false);
+
+  // Right source state
+  const [kernelsRight, setKernelsRight] = useState<ProcessedKernel[]>([]);
+  const [rightLoadedUrl, setRightLoadedUrl] = useState<string | null>(null);
+  const [loadingRight, setLoadingRight] = useState<boolean>(false);
+  const [errorRight, setErrorRight] = useState<string | null>(null);
+
+  // Selection state
+  const [leftIdx, setLeftIdx] = useState<number>(Math.max(0, selectedLeftIndex));
+  const [rightIdx, setRightIdx] = useState<number>(0);
+  const [mode, setMode] = useState<DiffMode>("single");
+  const [irType, setIrType] = useState<string>("ttgir");
+
+  // Diff options
+  const [ignoreWs, setIgnoreWs] = useState<boolean>(true);
+  const [wordLevel, setWordLevel] = useState<boolean>(true);
+  const [contextLines, setContextLines] = useState<number>(3);
+  const [wordWrap, setWordWrap] = useState<"off" | "on">("on");
+  const [onlyChanged, setOnlyChanged] = useState<boolean>(false);
+
+  // Read URL on mount
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    // Right URL
+    const bUrl = params.get(PARAM_JSON_B_URL);
+    if (bUrl) {
+      setRightLoadedUrl(bUrl);
+    }
+
+    // Left URL – use json_url only (no json_a_url)
+    const aUrl = params.get("json_url");
+    if (aUrl) {
+      setLeftLoadedUrlLocal(aUrl);
+    } else if (leftLoadedUrl) {
+      // Prop from App: treat as initial left URL
+      setLeftLoadedUrlLocal(leftLoadedUrl);
+    }
+
+    // Mode and IR
+    const modeParam = (params.get(PARAM_MODE) as DiffMode) || undefined;
+    if (modeParam === "single" || modeParam === "all") setMode(modeParam);
+    const irParam = params.get(PARAM_IR);
+    if (irParam) setIrType(irParam);
+
+    // Options
+    setIgnoreWs(params.get(PARAM_IGNORE_WS) === "0" ? false : true);
+    setWordLevel(params.get(PARAM_WORD_LEVEL) === "1");
+    const ctx = parseInt(params.get(PARAM_CONTEXT) || "");
+    if (!Number.isNaN(ctx)) setContextLines(ctx);
+    const wrap = params.get(PARAM_WRAP);
+    if (wrap === "on" || wrap === "off") setWordWrap(wrap);
+    setOnlyChanged(params.get(PARAM_ONLY_CHANGED) === "1");
+
+    // Left/Right kernel index by hash
+    const leftHash = params.get(PARAM_KERNEL_HASH_A);
+    const rightHash = params.get(PARAM_KERNEL_HASH_B);
+    if (leftHash) (window as any).__TRITONPARSE_leftHash = leftHash;
+    const li = findKernelIndexByHash(leftHash, kernelsLeft);
+    if (li >= 0) setLeftIdx(li);
+
+    // right index will be set after right kernels loaded
+    if (rightHash) {
+      // store temporarily in dataset
+      (window as any).__TRITONPARSE_rightHash = rightHash;
+    }
+  }, [kernelsLeft]);
+
+  // Load left URL when set (internal to FileDiffView)
+  useEffect(() => {
+    async function loadLeft(url: string) {
+      try {
+        const entries = await loadLogData(url);
+        const processed = processKernelData(entries);
+        setLeftKernelsFromUrl(processed);
+        setLeftLoadedFromLocal(false);
+        sess.setLeftFromUrl(url, processed);
+        // default to first kernel when loading new source
+        setLeftIdx(0);
+        try { sess.setLeftIdx(0); } catch {}
+        const leftHash = (window as any).__TRITONPARSE_leftHash as string | undefined;
+        if (leftHash) {
+          const li = findKernelIndexByHash(leftHash, processed);
+          if (li >= 0) setLeftIdx(li);
+          try { if (li >= 0) sess.setLeftIdx(li); } catch {}
+        }
+      } catch (e) {
+        console.warn('[FDV] loadLeft(URL) error:', e);
+        // ignore errors here; show via UI if needed later
+      }
+    }
+    if (leftLoadedUrlLocal) {
+      loadLeft(leftLoadedUrlLocal);
+    }
+  }, [leftLoadedUrlLocal]);
+
+  // Load right URL when set
+  useEffect(() => {
+    async function loadRight(url: string) {
+      try {
+        setLoadingRight(true);
+        setErrorRight(null);
+        const entries = await loadLogData(url);
+        const processed = processKernelData(entries);
+        setKernelsRight(processed);
+        sess.setRightFromUrl(url, processed);
+        // set right index by hash if present
+        const rightHash = (window as any).__TRITONPARSE_rightHash as string | undefined;
+        if (rightHash) {
+          const ri = findKernelIndexByHash(rightHash, processed);
+          if (ri >= 0) setRightIdx(ri);
+        }
+      } catch (e: any) {
+        setErrorRight(e?.message || String(e));
+      } finally {
+        setLoadingRight(false);
+      }
+    }
+    if (rightLoadedUrl) {
+      loadRight(rightLoadedUrl);
+    }
+  }, [rightLoadedUrl]);
+
+  // Hydrate session left from App props when coming from homepage/top bar load (including local file)
+  useEffect(() => {
+    try {
+      const sessLeftLen = sess.left?.kernels?.length || 0;
+      if (sessLeftLen === 0 && kernelsLeft.length > 0) {
+        if (leftLoadedUrl) {
+          sess.setLeftFromUrl(leftLoadedUrl, kernelsLeft);
+          
+        } else {
+          sess.setLeftFromLocal(kernelsLeft);
+          
+        }
+        sess.setLeftIdx(Math.max(0, leftIdx));
+      }
+    } catch {}
+  }, [sess, kernelsLeft, leftLoadedUrl, leftIdx]);
+
+  // Hydrate right from session when returning from preview (ensure right side is restored without reloading URL)
+  useEffect(() => {
+    try {
+      if (sess.right?.kernels?.length > 0) {
+        setKernelsRight(sess.right.kernels);
+        setRightIdx(Math.max(0, sess.right.selectedIdx));
+        if (sess.right.sourceType === 'url') {
+          setRightLoadedUrl(sess.right.url);
+          setRightLoadedFromLocal(false);
+        } else if (sess.right.sourceType === 'local') {
+          setRightLoadedUrl(null);
+          setRightLoadedFromLocal(true);
+        }
+      }
+    } catch {}
+  }, [sess.right]);
+
+  // Compute union ir types and choose default ir if needed
+  const unionIrTypes = useMemo(() => {
+    const leftArray = leftLoadedFromLocal
+      ? leftKernelsFromLocal
+      : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft);
+    const left = leftArray[leftIdx];
+    const right = kernelsRight[rightIdx];
+    const set = new Set<string>();
+    listIRTypesForKernel(left).forEach(t => set.add(t));
+    listIRTypesForKernel(right).forEach(t => set.add(t));
+    if (set.size === 0) return ["python"] as string[];
+    return Array.from(set);
+  }, [kernelsLeft, kernelsRight, leftIdx, rightIdx, leftLoadedFromLocal, leftKernelsFromLocal, leftLoadedUrlLocal, leftKernelsFromUrl]);
+
+  useEffect(() => {
+    if (!irType && unionIrTypes.length > 0) setIrType(unionIrTypes[0]);
+  }, [unionIrTypes, irType]);
+
+  // Update URL on state changes (File Diff owns its params)
+  const syncUrl = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set(PARAM_VIEW, "file_diff");
+    // left always present
+    const leftArray = leftLoadedFromLocal
+      ? leftKernelsFromLocal
+      : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft);
+    if (leftArray[leftIdx]?.metadata?.hash) params.set(PARAM_KERNEL_HASH_A, String(leftArray[leftIdx].metadata!.hash));
+    else params.delete(PARAM_KERNEL_HASH_A);
+    // right url/hash
+    if (rightLoadedUrl) params.set(PARAM_JSON_B_URL, rightLoadedUrl);
+    else params.delete(PARAM_JSON_B_URL);
+    if (kernelsRight[rightIdx]?.metadata?.hash) params.set(PARAM_KERNEL_HASH_B, String(kernelsRight[rightIdx].metadata!.hash));
+    else params.delete(PARAM_KERNEL_HASH_B);
+    // left url
+    if (leftLoadedFromLocal) params.delete("json_url");
+    else if (leftLoadedUrlLocal) params.set("json_url", leftLoadedUrlLocal);
+    else if (leftLoadedUrl) params.set("json_url", leftLoadedUrl); else params.delete("json_url");
+    // mode/ir
+    params.set(PARAM_MODE, mode);
+    if (mode === "single" && irType) params.set(PARAM_IR, irType);
+    else params.delete(PARAM_IR);
+    // options
+    params.set(PARAM_IGNORE_WS, ignoreWs ? "1" : "0");
+    params.set(PARAM_WORD_LEVEL, wordLevel ? "1" : "0");
+    params.set(PARAM_CONTEXT, String(contextLines));
+    params.set(PARAM_WRAP, wordWrap);
+    params.set(PARAM_ONLY_CHANGED, onlyChanged ? "1" : "0");
+    const newUrl = new URL(window.location.href);
+    newUrl.search = params.toString();
+    window.history.replaceState({}, "", newUrl.toString());
+  }, [kernelsLeft, kernelsRight, leftIdx, rightIdx, rightLoadedUrl, mode, irType, ignoreWs, wordLevel, contextLines, wordWrap, onlyChanged, leftLoadedFromLocal, leftLoadedUrlLocal, leftLoadedUrl, leftKernelsFromLocal, leftKernelsFromUrl]);
+
+  // Debounce URL updates to reduce history churn
+  useEffect(() => {
+    const id = setTimeout(() => {
+      syncUrl();
+    }, 200);
+    return () => clearTimeout(id);
+  }, [syncUrl]);
+
+  // UI builders
+  const leftArrayResolved = (sess.left?.kernels?.length || 0) > 0
+    ? sess.left.kernels
+    : (leftLoadedFromLocal
+      ? leftKernelsFromLocal
+      : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft));
+  const leftKernel = leftArrayResolved[leftIdx];
+  const rightKernel = kernelsRight[rightIdx];
+
+  // When navigating away, temporarily hide diff editors to avoid Monaco dispose race
+  const [hideDiff, setHideDiff] = useState<boolean>(false);
+  useEffect(() => {
+    // Reset when view state changes
+    setHideDiff(false);
+  }, [mode, irType, leftIdx, rightIdx]);
+
+  const renderSingle = () => {
+    const leftContent = getContentByIRType(leftKernel, irType);
+    const rightContent = getContentByIRType(rightKernel, irType);
+    const missingLeft = !leftContent;
+    const missingRight = !rightContent;
+    return (
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <div className="text-gray-700 font-medium">IR Type: <span className="text-blue-700">{irType}</span></div>
+          <div className="text-sm text-gray-500">
+            {missingLeft && <span className="mr-2">Left: Not available</span>}
+            {missingRight && <span>Right: Not available</span>}
+          </div>
+        </div>
+        {!hideDiff && (
+          <DiffComparisonView
+            leftContent={leftContent}
+            rightContent={rightContent}
+            height="calc(100vh - 14rem)"
+            language={irType === "python" ? "python" : "plaintext"}
+            options={{
+              ignoreWhitespace: ignoreWs,
+              wordLevel,
+              context: contextLines,
+              wordWrap,
+              onlyChanged,
+            }}
+          />
+        )}
+      </div>
+    );
+  };
+
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const toggle = (t: string) => setExpanded(prev => ({ ...prev, [t]: !prev[t] }));
+
+  const renderAll = () => {
+    return (
+      <div className="space-y-4">
+        {unionIrTypes.map((t) => {
+          const leftContent = getContentByIRType(leftKernel, t);
+          const rightContent = getContentByIRType(rightKernel, t);
+          const missingLeft = !leftContent;
+          const missingRight = !rightContent;
+          const isOpen = !!expanded[t];
+          return (
+            <div key={t} className="border border-gray-200 rounded bg-white">
+              <button
+                className="w-full text-left px-4 py-3 flex items-center justify-between hover:bg-gray-50"
+                onClick={() => toggle(t)}
+              >
+                <div className="font-medium text-gray-800">{t}</div>
+                <div className="text-sm text-gray-500">
+                  {missingLeft && <span className="mr-2">Left: N/A</span>}
+                  {missingRight && <span>Right: N/A</span>}
+                </div>
+              </button>
+              {isOpen && (
+                <div className="px-2 pb-2">
+                  {!hideDiff && (
+                    <DiffComparisonView
+                      leftContent={leftContent}
+                      rightContent={rightContent}
+                      height="calc(100vh - 14rem)"
+                      language={t === "python" ? "python" : "plaintext"}
+                      options={{
+                        ignoreWhitespace: ignoreWs,
+                        wordLevel,
+                        context: contextLines,
+                        wordWrap,
+                        onlyChanged,
+                      }}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  // Left and Right source loaders
+  const [pendingUrl, setPendingUrl] = useState<string>("");
+  const [rightLoadedFromLocal, setRightLoadedFromLocal] = useState<boolean>(false);
+  const handleLoadRight = async () => {
+    if (!pendingUrl) return;
+    setRightLoadedFromLocal(false);
+    setRightLoadedUrl(pendingUrl);
+  };
+
+  const handleLoadRightLocal = async (file: File | null) => {
+    if (!file) return;
+    try {
+      setLoadingRight(true);
+      setErrorRight(null);
+      const entries = await loadLogDataFromFile(file);
+      const processed = processKernelData(entries);
+      setKernelsRight(processed);
+      setRightLoadedFromLocal(true);
+      setRightLoadedUrl(null); // do not persist json_b_url when loaded from local file
+      sess.setRightFromLocal(processed);
+      // select the first kernel or restore by hash if available
+      const rightHash = (window as any).__TRITONPARSE_rightHash as string | undefined;
+      if (rightHash) {
+        const ri = findKernelIndexByHash(rightHash, processed);
+        setRightIdx(ri >= 0 ? ri : 0);
+      } else {
+        setRightIdx(0);
+      }
+    } catch (e: any) {
+      setErrorRight(e?.message || String(e));
+    } finally {
+      setLoadingRight(false);
+    }
+  };
+  const [leftPendingUrlLocal, setLeftPendingUrlLocal] = useState<string>("");
+  const handleLoadLeft = async () => {
+    if (!leftPendingUrlLocal) return;
+    setLeftLoadedFromLocal(false);
+    setLeftLoadedUrlLocal(leftPendingUrlLocal);
+  };
+  const handleLoadLeftLocal = async (file: File | null) => {
+    if (!file) return;
+    try {
+      const entries = await loadLogDataFromFile(file);
+      const processed = processKernelData(entries);
+      setLeftKernelsFromLocal(processed);
+      setLeftLoadedFromLocal(true);
+      setLeftLoadedUrlLocal(null);
+      sess.setLeftFromLocal(processed);
+      console.debug('[FDV] loadLeft(Local): kernels=', processed.length);
+      // select first by default
+      setLeftIdx(0);
+      try { sess.setLeftIdx(0); } catch {}
+      const leftHash = (window as any).__TRITONPARSE_leftHash as string | undefined;
+      if (leftHash) {
+        const li = findKernelIndexByHash(leftHash, processed);
+        setLeftIdx(li >= 0 ? li : 0);
+        try { if (li >= 0) sess.setLeftIdx(li); } catch {}
+      } else {
+        setLeftIdx(0);
+      }
+    } catch {}
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-800 mb-3">File Diff</h1>
+
+      <div className="bg-white rounded-lg p-3 mb-3 shadow border border-gray-200">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <div className="text-sm text-gray-500 mb-1">Left Source (json_url)</div>
+            <div className="flex items-center gap-2 mb-2">
+              <input
+                type="url"
+                placeholder="https://.../trace.ndjson.gz"
+                className="flex-1 border border-gray-300 rounded px-3 py-2"
+                value={leftPendingUrlLocal}
+                onChange={(e) => setLeftPendingUrlLocal(e.target.value)}
+              />
+              <button
+                className="px-3 py-2 bg-blue-600 text-white rounded"
+                onClick={handleLoadLeft}
+              >
+                Load
+              </button>
+            </div>
+            <div className="flex items-center gap-2 mb-2">
+              <input
+                type="file"
+                accept=".ndjson,.ndjson.gz,.gz,.jsonl"
+                className="block w-full text-sm text-gray-700"
+                onChange={(e) => handleLoadLeftLocal(e.target.files?.[0] || null)}
+              />
+            </div>
+            {(leftLoadedUrlLocal || leftLoadedUrl || (leftLoadedFromLocal || kernelsLeft.length > 0)) && (
+              <div className="text-gray-800 break-all mb-2">
+                {leftLoadedUrlLocal || leftLoadedUrl || "(from local file)"}
+              </div>
+            )}
+            {leftLoadedFromLocal && (
+              <div className="text-gray-600 text-sm mb-2">(loaded from local file)</div>
+            )}
+            <div className="flex gap-2 mt-1">
+              <button
+                className="px-2 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded border"
+                disabled={leftArrayResolved.length === 0}
+                onClick={() => { console.debug('[FDV] click Left→Overview', { leftIdx }); setHideDiff(true); setTimeout(() => sess.gotoOverview('left'), 0); }}
+              >
+                Left → Kernel Overview
+              </button>
+              <button
+                className="px-2 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded border"
+                disabled={leftArrayResolved.length === 0}
+                onClick={() => { console.debug('[FDV] click Left→IR', { leftIdx }); setHideDiff(true); setTimeout(() => sess.gotoIRCode('left'), 0); }}
+              >
+                Left → IR Code
+              </button>
+            </div>
+          </div>
+          <div>
+            <div className="text-sm text-gray-500 mb-1">Right Source (json_b_url)</div>
+            <div className="flex items-center gap-2 mb-2">
+              <input
+                type="url"
+                placeholder="https://.../trace.ndjson.gz"
+                className="flex-1 border border-gray-300 rounded px-3 py-2"
+                value={pendingUrl}
+                onChange={(e) => setPendingUrl(e.target.value)}
+              />
+              <button
+                className="px-3 py-2 bg-blue-600 text-white rounded"
+                onClick={handleLoadRight}
+                disabled={loadingRight}
+              >
+                {loadingRight ? "Loading..." : "Load"}
+              </button>
+            </div>
+            <div className="flex items-center gap-2 mb-2">
+              <input
+                type="file"
+                accept=".ndjson,.ndjson.gz,.gz,.jsonl"
+                className="block w-full text-sm text-gray-700"
+                onChange={(e) => handleLoadRightLocal(e.target.files?.[0] || null)}
+                disabled={loadingRight}
+              />
+            </div>
+            {rightLoadedUrl && (
+              <div className="text-gray-800 break-all mb-2">{rightLoadedUrl}</div>
+            )}
+            {rightLoadedFromLocal && (
+              <div className="text-gray-600 text-sm mb-2">(loaded from local file)</div>
+            )}
+            {errorRight && (
+              <div className="text-red-600 text-sm mb-2">{errorRight}</div>
+            )}
+            {/* Right kernel select moved to aligned row below */}
+            <div className="flex gap-2 mt-1">
+              <button
+                className="px-2 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded border"
+                disabled={kernelsRight.length === 0}
+                onClick={() => { setHideDiff(true); setTimeout(() => sess.gotoOverview('right'), 0); }}
+              >
+                Right → Kernel Overview
+              </button>
+              <button
+                className="px-2 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded border"
+                disabled={kernelsRight.length === 0}
+                onClick={() => { setHideDiff(true); setTimeout(() => sess.gotoIRCode('right'), 0); }}
+              >
+                Right → IR Code
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Aligned kernel selectors row */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-2">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Left Kernel</label>
+            <select
+              className="border border-gray-300 rounded px-3 py-2 bg-white w-full"
+              value={leftIdx}
+              onChange={(e) => { const v = parseInt(e.target.value); setLeftIdx(v); try { sess.setLeftIdx(v); } catch {} }}
+              disabled={leftArrayResolved.length === 0}
+            >
+              {leftArrayResolved.map((k, i) => (
+                <option key={`l-${i}`} value={i}>
+                  {k.name} {(k.metadata?.hash || "").slice(0, 8)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Right Kernel</label>
+            <select
+              className="border border-gray-300 rounded px-3 py-2 bg-white w-full"
+              value={rightIdx}
+              onChange={(e) => { const v = parseInt(e.target.value); setRightIdx(v); try { sess.setRightIdx(v); } catch {} }}
+              disabled={kernelsRight.length === 0}
+            >
+              {kernelsRight.map((k, i) => (
+                <option key={`r-${i}`} value={i}>
+                  {k.name} {(k.metadata?.hash || "").slice(0, 8)}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mt-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Mode</label>
+            <div className="flex items-center gap-2">
+              <button className={`px-3 py-1 rounded ${mode === "single" ? "bg-blue-600 text-white" : "bg-gray-100"}`} onClick={() => setMode("single")}>Single IR</button>
+              <button className={`px-3 py-1 rounded ${mode === "all" ? "bg-blue-600 text-white" : "bg-gray-100"}`} onClick={() => setMode("all")}>All IRs</button>
+            </div>
+          </div>
+          {mode === "single" && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">IR Type</label>
+              <select
+                className="border border-gray-300 rounded px-3 py-2 bg-white w-full"
+                value={irType}
+                onChange={(e) => setIrType(e.target.value)}
+              >
+                {unionIrTypes.map(t => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Diff Options</label>
+            <div className="flex flex-wrap gap-2">
+              <label className="inline-flex items-center gap-1 text-sm">
+                <input type="checkbox" checked={ignoreWs} onChange={(e) => setIgnoreWs(e.target.checked)} />
+                Ignore whitespace
+              </label>
+              <label className="inline-flex items-center gap-1 text-sm">
+                <input type="checkbox" checked={onlyChanged} onChange={(e) => setOnlyChanged(e.target.checked)} />
+                Only changes
+              </label>
+              <label className="inline-flex items-center gap-1 text-sm">
+                <input type="checkbox" checked={wordLevel} onChange={(e) => setWordLevel(e.target.checked)} />
+                Word-level
+              </label>
+              <label className="inline-flex items-center gap-1 text-sm">
+                <span>Context</span>
+                <input type="number" className="w-16 border border-gray-300 rounded px-2 py-1" value={contextLines} onChange={(e) => setContextLines(parseInt(e.target.value) || 0)} />
+              </label>
+              <label className="inline-flex items-center gap-1 text-sm">
+                <span>Wrap</span>
+                <select className="border border-gray-300 rounded px-2 py-1" value={wordWrap} onChange={(e) => setWordWrap(e.target.value as any)}>
+                  <option value="off">off</option>
+                  <option value="on">on</option>
+                </select>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {mode === "single" ? renderSingle() : renderAll()}
+    </div>
+  );
+};
+
+export default FileDiffView;
+
+


### PR DESCRIPTION

#### Summary
- Hardens Monaco Diff Editor lifecycle and option synchronization for consistent VSCode-style diffs.
- Ensures both sides have word wrap on by default and mitigates disposal errors during navigation.

#### Key Changes
- `website/src/components/DiffComparisonView.tsx` sets `wordWrap`, `wordWrapOverride1/2`, `diffWordWrap`, `wordWrapMinified`, `wrappingStrategy` and updates options on layout/events.
- Adds explicit `editor.dispose()` and `editor.setModel(null)` in unmount cleanup to prevent "TextModel got disposed" errors.
- `FileDiffView` optionally unmounts diff (`hideDiff`) before navigation to avoid Monaco race conditions.

