### PR TITLE
[BE-Breaking] Refactored the CLI from single-command to subcommand structure. 

### DIFF
--- a/tritonparse/reproducer/cli.py
+++ b/tritonparse/reproducer/cli.py
@@ -1,0 +1,19 @@
+import argparse
+
+
+def _add_reproducer_args(parser: argparse.ArgumentParser) -> None:
+    """Add common arguments for the reproducer to a parser."""
+    parser.add_argument("input", help="Path to the ndjson/ndjson.gz log file")
+    parser.add_argument(
+        "--line-index",
+        type=int,
+        help="The line number of the launch event in the input file to reproduce.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help=(
+            "Directory to save the reproducer script and context JSON. Defaults to "
+            "'repro_output/<kernel_name>/' if not provided."
+        ),
+    )

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,0 +1,13 @@
+from tritonparse.tp_logger import logger
+from tritonparse.tools.prettify_ndjson import load_ndjson
+from pathlib import Path
+
+def reproducer(
+    input_path: str,
+    line_index: int,
+    out_dir: str,
+):
+    logger.debug(f"Building bundle from {input_path} at line {line_index}")
+    events = load_ndjson(
+        Path(input_path), save_irs=True
+    )

--- a/tritonparse/utils.py
+++ b/tritonparse/utils.py
@@ -16,21 +16,15 @@ from .common import (
 )
 from .source_type import Source, SourceType
 
-# argument parser for OSS
-parser = None
 
-
-def init_parser():
-    global parser
-
-    parser = argparse.ArgumentParser(
-        description="analyze triton structured logs", conflict_handler="resolve"
-    )
-
-    # Add arguments for the parse command
+def _add_parse_args(parser: argparse.ArgumentParser) -> None:
+    """Add common 'parse' subcommand arguments to a parser."""
     parser.add_argument(
         "source",
-        help="Source of torch logs to be analyzed. It is expected to path to a local directory or log",
+        help=(
+            "Source of torch logs to be analyzed. It is expected to path to a local "
+            "directory or log"
+        ),
     )
     parser.add_argument(
         "-o",
@@ -40,7 +34,9 @@ def init_parser():
     )
     parser.add_argument(
         "--overwrite",
-        help="Delete out directory if it already exists. Only does something if --out is set",
+        help=(
+            "Delete out directory if it already exists. Only does something if --out is set"
+        ),
         action="store_true",
     )
     parser.add_argument("-r", "--rank", help="Rank of logs to be analyzed", type=int)
@@ -54,7 +50,6 @@ def init_parser():
         from tritonparse.fb.utils import append_parser
 
         append_parser(parser)
-    return parser
 
 
 def oss_run(
@@ -111,12 +106,6 @@ def oss_run(
     else:
         out_dir = str(Path(parsed_log_dir).absolute())
     print_parsed_files_summary(out_dir)
-
-
-def unified_parse_from_cli():
-    parser = init_parser()
-    args = parser.parse_args()
-    return unified_parse(**vars(args))
 
 
 def unified_parse(


### PR DESCRIPTION
Introduce a subcommand-based CLI and the first reproducer scaffold.


```bash
python run.py parse <source> [options...]
python run.py reproduce <ndjson_file> [options...]
```


- **CLI (breaking)**: Switch from a single entry to subcommands in `run.py`:
  - Old CLI `python run.py <source>` no longer works
  - `parse` runs the structured log parser.
  - `reproduce` (new) starts the reproducer flow.
  - Extract parser flags into `tritonparse.utils._add_parse_args(...)`; remove `unified_parse_from_cli` (programmatic `unified_parse(...)` remains).

- **Reproducer scaffold**: Add `tritonparse/reproducer/cli.py` and `tritonparse/reproducer/orchestrator.py`.
  - Orchestrator loads NDJSON via `prettify_ndjson.load_ndjson(..., save_irs=True)` and logs intent; later PRs extend this into bundling and codegen.

- **Files changed**: `run.py`; `tritonparse/reproducer/cli.py` (new); `tritonparse/reproducer/orchestrator.py` (new); `tritonparse/utils.py`
