### PR TITLE
[Reproducer] PR3: Add NDJSON ingestion layer; orchestrator refactor to use it

### DIFF
--- a/tritonparse/reproducer/cli.py
+++ b/tritonparse/reproducer/cli.py
@@ -1,0 +1,19 @@
+import argparse
+
+
+def _add_reproducer_args(parser: argparse.ArgumentParser) -> None:
+    """Add common arguments for the reproducer to a parser."""
+    parser.add_argument("input", help="Path to the ndjson/ndjson.gz log file")
+    parser.add_argument(
+        "--line-index",
+        type=int,
+        help="The line number of the launch event in the input file to reproduce.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help=(
+            "Directory to save the reproducer script and context JSON. Defaults to "
+            "'repro_output/<kernel_name>/' if not provided."
+        ),
+    )

--- a/tritonparse/reproducer/ingestion/ndjson.py
+++ b/tritonparse/reproducer/ingestion/ndjson.py
@@ -1,0 +1,129 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from tritonparse.tp_logger import logger
+
+
+@dataclass
+class KernelInfo:
+    """Information about a Triton kernel extracted from compilation events."""
+
+    file_path: str
+    function_name: str
+    source_code: str
+    call_stack: List[Dict[str, Any]]
+
+
+def get_launch_and_compilation_events(
+    events: List[Dict[str, Any]], line_index: Optional[int] = None
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Extract launch and compilation events from the event list.
+
+    Args:
+        events: List of parsed event dictionaries.
+        line_index: Index of the launch event to process.
+
+    Returns:
+        Tuple of (launch_event, compilation_event).
+
+    Raises:
+        ValueError: If the event at line_index is not a launch event.
+        RuntimeError: If compilation event cannot be found or is ambiguous.
+    """
+    if line_index is None or line_index >= len(events):
+        raise ValueError(f"Invalid line_index: {line_index}")
+
+    launch_event = events[line_index]
+    if launch_event["event_type"] != "launch":
+        raise ValueError(f"Event at index {line_index} is not a launch event")
+
+    comp_meta = launch_event.get("compilation_metadata", {})
+    comp_hash = comp_meta.get("hash")
+    if not comp_hash:
+        raise RuntimeError("Could not find compilation hash in launch event.")
+
+    comp_event = [
+        event
+        for event in events
+        if event["event_type"] == "compilation" and event.get("hash") == comp_hash
+    ]
+    if not comp_event:
+        raise RuntimeError(f"Could not find compilation event for hash {comp_hash}.")
+    if len(comp_event) != 1:
+        raise RuntimeError(
+            f"Expected 1 compilation event for hash {comp_hash}, got {len(comp_event)}"
+        )
+
+    return launch_event, comp_event[0]
+
+
+def get_kernel_info(comp_event: Dict[str, Any]) -> KernelInfo:
+    """
+    Extract kernel information from a compilation event.
+
+    Args:
+        comp_event: Compilation event dictionary containing kernel metadata.
+
+    Returns:
+        KernelInfo object with extracted kernel details.
+
+    Raises:
+        RuntimeError: If file path or function name cannot be resolved.
+    """
+    payload = comp_event.get("payload") or {}
+    py_source = payload.get("python_source") or {}
+    code = py_source.get("code", "")
+
+    # Extract file path and function name
+    file_path = py_source.get("file_path")
+    # The function name is in the compilation metadata payload
+    func_name = (comp_event.get("payload", {}).get("metadata") or {}).get("name")
+
+    # Find '@triton.jit' decorator and slice the string from there
+    jit_marker = "@triton.jit"
+    jit_pos = code.find(jit_marker)
+    if jit_pos != -1:
+        code = code[jit_pos:]
+        logger.debug("Extracted kernel source starting from '@triton.jit'.")
+
+    if not file_path or not func_name:
+        raise RuntimeError(
+            "Could not resolve kernel file path or function name from compilation event."
+            " The import-based strategy cannot proceed."
+        )
+    return KernelInfo(file_path, func_name, code, comp_event.get("stack", []))
+
+
+def build_context_bundle(
+    events: List[Dict[str, Any]], line_index: Optional[int] = None
+):
+    """
+    Build a complete context bundle from events and line index.
+
+    Args:
+        events: List of parsed event dictionaries.
+        line_index: Index of the launch event to process.
+
+    Returns:
+        ContextBundle containing all information needed to reproduce the kernel launch.
+
+    Raises:
+        ValueError: If line_index is invalid or event is not a launch event.
+        RuntimeError: If compilation event cannot be found.
+    """
+    launch_event, comp_event = get_launch_and_compilation_events(events, line_index)
+    kernel_info = get_kernel_info(comp_event)
+    grid = launch_event.get("grid")
+    extracted_args = launch_event.get("extracted_args", {})
+    comp_meta = launch_event.get("compilation_metadata", {})
+
+    # Compile metadata subset we care about
+    compile_block = {
+        "num_warps": comp_meta.get("num_warps"),
+        "num_stages": comp_meta.get("num_stages"),
+        "arch": comp_meta.get("arch"),
+        "backend": comp_meta.get("backend_name") or comp_meta.get("backend"),
+        "triton_version": comp_meta.get("triton_version"),
+        "hash": comp_meta.get("hash"),
+    }

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,6 +1,8 @@
-from tritonparse.tp_logger import logger
-from tritonparse.tools.prettify_ndjson import load_ndjson
 from pathlib import Path
+
+from tritonparse.tools.prettify_ndjson import load_ndjson
+from tritonparse.tp_logger import logger
+
 
 def reproducer(
     input_path: str,
@@ -8,6 +10,4 @@ def reproducer(
     out_dir: str,
 ):
     logger.debug(f"Building bundle from {input_path} at line {line_index}")
-    events = load_ndjson(
-        Path(input_path), save_irs=True
-    )
+    events = load_ndjson(Path(input_path), save_irs=True)

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,0 +1,13 @@
+from tritonparse.tp_logger import logger
+from tritonparse.tools.prettify_ndjson import load_ndjson
+from pathlib import Path
+
+def reproducer(
+    input_path: str,
+    line_index: int,
+    out_dir: str,
+):
+    logger.debug(f"Building bundle from {input_path} at line {line_index}")
+    events = load_ndjson(
+        Path(input_path), save_irs=True
+    )

--- a/tritonparse/utils.py
+++ b/tritonparse/utils.py
@@ -16,21 +16,15 @@ from .common import (
 )
 from .source_type import Source, SourceType
 
-# argument parser for OSS
-parser = None
 
-
-def init_parser():
-    global parser
-
-    parser = argparse.ArgumentParser(
-        description="analyze triton structured logs", conflict_handler="resolve"
-    )
-
-    # Add arguments for the parse command
+def _add_parse_args(parser: argparse.ArgumentParser) -> None:
+    """Add common 'parse' subcommand arguments to a parser."""
     parser.add_argument(
         "source",
-        help="Source of torch logs to be analyzed. It is expected to path to a local directory or log",
+        help=(
+            "Source of torch logs to be analyzed. It is expected to path to a local "
+            "directory or log"
+        ),
     )
     parser.add_argument(
         "-o",
@@ -40,7 +34,9 @@ def init_parser():
     )
     parser.add_argument(
         "--overwrite",
-        help="Delete out directory if it already exists. Only does something if --out is set",
+        help=(
+            "Delete out directory if it already exists. Only does something if --out is set"
+        ),
         action="store_true",
     )
     parser.add_argument("-r", "--rank", help="Rank of logs to be analyzed", type=int)
@@ -54,7 +50,6 @@ def init_parser():
         from tritonparse.fb.utils import append_parser
 
         append_parser(parser)
-    return parser
 
 
 def oss_run(
@@ -111,12 +106,6 @@ def oss_run(
     else:
         out_dir = str(Path(parsed_log_dir).absolute())
     print_parsed_files_summary(out_dir)
-
-
-def unified_parse_from_cli():
-    parser = init_parser()
-    args = parser.parse_args()
-    return unified_parse(**vars(args))
 
 
 def unified_parse(


### PR DESCRIPTION
Introduce an NDJSON ingestion layer and refactor the orchestrator to use it. The ingestion module formalizes how we locate the target launch event, match its compilation event, extract kernel metadata, and normalize arguments (tensors vs scalars).

- **New ingestion module**: `tritonparse/reproducer/ingestion/ndjson.py`
  - Dataclasses:
    - `KernelInfo` captures `file_path`, `function_name`, kernel `source_code` (trimmed from `@triton.jit` onward), and `call_stack`.
    - `ContextBundle` aggregates everything needed for reproduction: `kernel_info`, a `compile` block, a `launch` block, `args` (primitive/scalars), `tensor_args` (tensor-only with shape/dtype/device/stride/contiguity/numel), and the raw launch/compilation events.
  - Event selection and validation:
    - `get_launch_and_compilation_events(events, line_index)` ensures the indexed event is a launch and finds the matching compilation event by hash (errors if missing/invalid).
    - `get_kernel_info(comp_event)` extracts kernel metadata; trims Python source around the Triton decorator; errors if file/function cannot be resolved.
  - Argument normalization:
    - `_decode_arg` skips tensor payloads via an internal sentinel and decodes non-tensor scalars/None.
    - `_pack_args` serializes both primitive and tensor arguments into a uniform schema including types and key metadata.
  - `build_context_bundle(...)` assembles the full bundle including a compile metadata subset (`num_warps`, `num_stages`, `arch`, `backend`, `triton_version`, `hash`) and a launch block (`grid`, `kwargs`).

- **Orchestrator refactor**: `tritonparse/reproducer/orchestrator.py`
  - Switch to `build_context_bundle(...)` for constructing the single-source-of-truth context used by later steps (template fill, import generation, signature parsing, invocation emission).
  - Logs the target kernel name and computes output paths based on the kernel function to prepare for code emission in follow-up PRs.

- **Change stats**: 2 files changed, 134 insertions(+), 5 deletions(-)
- **Files changed**: `tritonparse/reproducer/ingestion/ndjson.py` (new); `tritonparse/reproducer/orchestrator.py`