### PR TITLE
[Reproducer] PR5: Standardize output paths for reproducer artifacts

### DIFF
--- a/tritonparse/reproducer/cli.py
+++ b/tritonparse/reproducer/cli.py
@@ -11,7 +11,7 @@ def _add_reproducer_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--out-dir",
-        default=None,
+        default="repro_output",
         help=(
             "Directory to save the reproducer script and context JSON. Defaults to "
             "'repro_output/<kernel_name>/' if not provided."

--- a/tritonparse/reproducer/cli.py
+++ b/tritonparse/reproducer/cli.py
@@ -1,0 +1,19 @@
+import argparse
+
+
+def _add_reproducer_args(parser: argparse.ArgumentParser) -> None:
+    """Add common arguments for the reproducer to a parser."""
+    parser.add_argument("input", help="Path to the ndjson/ndjson.gz log file")
+    parser.add_argument(
+        "--line-index",
+        type=int,
+        help="The line number of the launch event in the input file to reproduce.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help=(
+            "Directory to save the reproducer script and context JSON. Defaults to "
+            "'repro_output/<kernel_name>/' if not provided."
+        ),
+    )

--- a/tritonparse/reproducer/ingestion/ndjson.py
+++ b/tritonparse/reproducer/ingestion/ndjson.py
@@ -1,0 +1,129 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from tritonparse.tp_logger import logger
+
+
+@dataclass
+class KernelInfo:
+    """Information about a Triton kernel extracted from compilation events."""
+
+    file_path: str
+    function_name: str
+    source_code: str
+    call_stack: List[Dict[str, Any]]
+
+
+def get_launch_and_compilation_events(
+    events: List[Dict[str, Any]], line_index: Optional[int] = None
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Extract launch and compilation events from the event list.
+
+    Args:
+        events: List of parsed event dictionaries.
+        line_index: Index of the launch event to process.
+
+    Returns:
+        Tuple of (launch_event, compilation_event).
+
+    Raises:
+        ValueError: If the event at line_index is not a launch event.
+        RuntimeError: If compilation event cannot be found or is ambiguous.
+    """
+    if line_index is None or line_index >= len(events):
+        raise ValueError(f"Invalid line_index: {line_index}")
+
+    launch_event = events[line_index]
+    if launch_event["event_type"] != "launch":
+        raise ValueError(f"Event at index {line_index} is not a launch event")
+
+    comp_meta = launch_event.get("compilation_metadata", {})
+    comp_hash = comp_meta.get("hash")
+    if not comp_hash:
+        raise RuntimeError("Could not find compilation hash in launch event.")
+
+    comp_event = [
+        event
+        for event in events
+        if event["event_type"] == "compilation" and event.get("hash") == comp_hash
+    ]
+    if not comp_event:
+        raise RuntimeError(f"Could not find compilation event for hash {comp_hash}.")
+    if len(comp_event) != 1:
+        raise RuntimeError(
+            f"Expected 1 compilation event for hash {comp_hash}, got {len(comp_event)}"
+        )
+
+    return launch_event, comp_event[0]
+
+
+def get_kernel_info(comp_event: Dict[str, Any]) -> KernelInfo:
+    """
+    Extract kernel information from a compilation event.
+
+    Args:
+        comp_event: Compilation event dictionary containing kernel metadata.
+
+    Returns:
+        KernelInfo object with extracted kernel details.
+
+    Raises:
+        RuntimeError: If file path or function name cannot be resolved.
+    """
+    payload = comp_event.get("payload") or {}
+    py_source = payload.get("python_source") or {}
+    code = py_source.get("code", "")
+
+    # Extract file path and function name
+    file_path = py_source.get("file_path")
+    # The function name is in the compilation metadata payload
+    func_name = (comp_event.get("payload", {}).get("metadata") or {}).get("name")
+
+    # Find '@triton.jit' decorator and slice the string from there
+    jit_marker = "@triton.jit"
+    jit_pos = code.find(jit_marker)
+    if jit_pos != -1:
+        code = code[jit_pos:]
+        logger.debug("Extracted kernel source starting from '@triton.jit'.")
+
+    if not file_path or not func_name:
+        raise RuntimeError(
+            "Could not resolve kernel file path or function name from compilation event."
+            " The import-based strategy cannot proceed."
+        )
+    return KernelInfo(file_path, func_name, code, comp_event.get("stack", []))
+
+
+def build_context_bundle(
+    events: List[Dict[str, Any]], line_index: Optional[int] = None
+):
+    """
+    Build a complete context bundle from events and line index.
+
+    Args:
+        events: List of parsed event dictionaries.
+        line_index: Index of the launch event to process.
+
+    Returns:
+        ContextBundle containing all information needed to reproduce the kernel launch.
+
+    Raises:
+        ValueError: If line_index is invalid or event is not a launch event.
+        RuntimeError: If compilation event cannot be found.
+    """
+    launch_event, comp_event = get_launch_and_compilation_events(events, line_index)
+    kernel_info = get_kernel_info(comp_event)
+    grid = launch_event.get("grid")
+    extracted_args = launch_event.get("extracted_args", {})
+    comp_meta = launch_event.get("compilation_metadata", {})
+
+    # Compile metadata subset we care about
+    compile_block = {
+        "num_warps": comp_meta.get("num_warps"),
+        "num_stages": comp_meta.get("num_stages"),
+        "arch": comp_meta.get("arch"),
+        "backend": comp_meta.get("backend_name") or comp_meta.get("backend"),
+        "triton_version": comp_meta.get("triton_version"),
+        "hash": comp_meta.get("hash"),
+    }

--- a/tritonparse/reproducer/ingestion/ndjson.py
+++ b/tritonparse/reproducer/ingestion/ndjson.py
@@ -3,6 +3,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from tritonparse.tp_logger import logger
 
+# Sentinel object to mark arguments that should be skipped during processing
+_SKIP = object()
+
 
 @dataclass
 class KernelInfo:
@@ -12,6 +15,17 @@ class KernelInfo:
     function_name: str
     source_code: str
     call_stack: List[Dict[str, Any]]
+
+
+@dataclass
+class ContextBundle:
+    """Bundle of all context information needed to reproduce a kernel launch."""
+
+    kernel_info: KernelInfo
+    compile: Dict[str, Any]
+    launch: Dict[str, Any]
+    args: Dict[str, Any]
+    tensor_args: Dict[str, Any]
 
 
 def get_launch_and_compilation_events(
@@ -95,6 +109,66 @@ def get_kernel_info(comp_event: Dict[str, Any]) -> KernelInfo:
     return KernelInfo(file_path, func_name, code, comp_event.get("stack", []))
 
 
+def _decode_arg(raw: Any) -> Any:
+    """
+    Decode a raw argument value from event data.
+
+    Args:
+        raw: Raw argument value from event data.
+
+    Returns:
+        Decoded argument value, or _SKIP sentinel for tensors.
+    """
+    if not isinstance(raw, dict):
+        return raw
+    t = raw.get("type")
+    if t == "tensor":
+        return _SKIP
+    if t == "NoneType":
+        return None
+    return raw.get("value", raw.get("repr"))
+
+
+def _pack_args(args: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Pack argument values into a standardized format.
+
+    Args:
+        args: Dictionary of argument names to values.
+
+    Returns:
+        Dictionary with packed argument information including type and metadata.
+    """
+    packed = {}
+    for k, v in args.items():
+        t = v.get("type") if isinstance(v, dict) else None
+        if t == "tensor":
+            packed[k] = {
+                "type": "tensor",
+                "shape": v.get("shape") if isinstance(v, dict) else None,
+                "dtype": v.get("dtype") if isinstance(v, dict) else None,
+                "device": v.get("device") if isinstance(v, dict) else None,
+                "stride": v.get("stride") if isinstance(v, dict) else None,
+                "is_contiguous": (
+                    v.get("is_contiguous") if isinstance(v, dict) else None
+                ),
+                "numel": v.get("numel") if isinstance(v, dict) else None,
+            }
+        else:
+            # scalar / NoneType etc
+            if isinstance(v, dict):
+                packed[k] = {
+                    "type": v.get("type"),
+                    "value": v.get("value", v.get("repr")),
+                }
+            else:
+                packed[k] = {
+                    "type": None,
+                    "value": v,
+                }
+    return packed
+
+
 def build_context_bundle(
     events: List[Dict[str, Any]], line_index: Optional[int] = None
 ):
@@ -127,3 +201,29 @@ def build_context_bundle(
         "triton_version": comp_meta.get("triton_version"),
         "hash": comp_meta.get("hash"),
     }
+
+    # kwargs: include constexpr + explicit scalars used for launch (skip tensor args)
+    kwargs = {}
+    for k, v in extracted_args.items():
+        val = _decode_arg(v)
+        if val is _SKIP:
+            continue
+        kwargs[k] = val
+
+    # tensor args: only tensors
+    raw_tensor_args = {
+        k: v
+        for k, v in extracted_args.items()
+        if isinstance(v, dict) and v.get("type") == "tensor"
+    }
+
+    primitive_args = _pack_args(extracted_args)
+    tensor_args = _pack_args(raw_tensor_args)
+    launch_block = {
+        "grid": grid,
+        "kwargs": kwargs,
+    }
+
+    return ContextBundle(
+        kernel_info, compile_block, launch_block, primitive_args, tensor_args
+    )

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,6 +1,8 @@
-from tritonparse.tp_logger import logger
-from tritonparse.tools.prettify_ndjson import load_ndjson
 from pathlib import Path
+
+from tritonparse.tools.prettify_ndjson import load_ndjson
+from tritonparse.tp_logger import logger
+
 
 def reproducer(
     input_path: str,
@@ -8,6 +10,4 @@ def reproducer(
     out_dir: str,
 ):
     logger.debug(f"Building bundle from {input_path} at line {line_index}")
-    events = load_ndjson(
-        Path(input_path), save_irs=True
-    )
+    events = load_ndjson(Path(input_path), save_irs=True)

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from tritonparse.reproducer.ingestion.ndjson import build_context_bundle
+
 from tritonparse.tools.prettify_ndjson import load_ndjson
 from tritonparse.tp_logger import logger
 
@@ -9,5 +11,20 @@ def reproducer(
     line_index: int,
     out_dir: str,
 ):
+    """
+    Generate a reproducer script from NDJSON trace file.
+
+    Args:
+        input_path: Path to the NDJSON trace file.
+        line_index: Line index of the launch event to reproduce.
+        out_dir: Output directory for reproducer files.
+    """
     logger.debug(f"Building bundle from {input_path} at line {line_index}")
     events = load_ndjson(Path(input_path), save_irs=True)
+    logger.debug(f"Loaded {len(events)} events")
+
+    # Build context bundle from the specified launch event
+    context_bundle = build_context_bundle(events, line_index)
+    logger.debug(
+        f"Built context bundle for kernel: {context_bundle.kernel_info.function_name}"
+    )

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,0 +1,13 @@
+from tritonparse.tp_logger import logger
+from tritonparse.tools.prettify_ndjson import load_ndjson
+from pathlib import Path
+
+def reproducer(
+    input_path: str,
+    line_index: int,
+    out_dir: str,
+):
+    logger.debug(f"Building bundle from {input_path} at line {line_index}")
+    events = load_ndjson(
+        Path(input_path), save_irs=True
+    )

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from tritonparse.reproducer.ingestion.ndjson import build_context_bundle
+from tritonparse.reproducer.utils import determine_output_paths
 
 from tritonparse.tools.prettify_ndjson import load_ndjson
 from tritonparse.tp_logger import logger
@@ -27,4 +28,7 @@ def reproducer(
     context_bundle = build_context_bundle(events, line_index)
     logger.debug(
         f"Built context bundle for kernel: {context_bundle.kernel_info.function_name}"
+    )
+    out_py_path, temp_json_path = determine_output_paths(
+        out_dir, context_bundle.kernel_info.function_name
     )

--- a/tritonparse/reproducer/utils.py
+++ b/tritonparse/reproducer/utils.py
@@ -2,7 +2,9 @@ import importlib
 import importlib.util
 import json
 import sys
+from datetime import datetime
 from functools import lru_cache
+from pathlib import Path
 
 import torch
 
@@ -145,3 +147,24 @@ def _create_arg_from_info(arg_info):
     else:
         print(f"Warning: Unhandled argument type '{arg_type}'. Returning None.")
         return None
+
+
+def determine_output_paths(out_dir: str, kernel_name: str):
+    """
+    Determine output file paths for reproducer script and context data.
+
+    Args:
+        out_dir: Output directory path. If empty, uses default location.
+        kernel_name: Name of the kernel for default directory naming.
+
+    Returns:
+        Tuple of (python_script_path, json_context_path) as Path objects.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    output_directory = Path(out_dir) / kernel_name
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    out_py_path = output_directory / f"repro_{timestamp}.py"
+    temp_json_path = output_directory / f"repro_context_{timestamp}.json"
+
+    return out_py_path, temp_json_path

--- a/tritonparse/utils.py
+++ b/tritonparse/utils.py
@@ -16,21 +16,15 @@ from .common import (
 )
 from .source_type import Source, SourceType
 
-# argument parser for OSS
-parser = None
 
-
-def init_parser():
-    global parser
-
-    parser = argparse.ArgumentParser(
-        description="analyze triton structured logs", conflict_handler="resolve"
-    )
-
-    # Add arguments for the parse command
+def _add_parse_args(parser: argparse.ArgumentParser) -> None:
+    """Add common 'parse' subcommand arguments to a parser."""
     parser.add_argument(
         "source",
-        help="Source of torch logs to be analyzed. It is expected to path to a local directory or log",
+        help=(
+            "Source of torch logs to be analyzed. It is expected to path to a local "
+            "directory or log"
+        ),
     )
     parser.add_argument(
         "-o",
@@ -40,7 +34,9 @@ def init_parser():
     )
     parser.add_argument(
         "--overwrite",
-        help="Delete out directory if it already exists. Only does something if --out is set",
+        help=(
+            "Delete out directory if it already exists. Only does something if --out is set"
+        ),
         action="store_true",
     )
     parser.add_argument("-r", "--rank", help="Rank of logs to be analyzed", type=int)
@@ -54,7 +50,6 @@ def init_parser():
         from tritonparse.fb.utils import append_parser
 
         append_parser(parser)
-    return parser
 
 
 def oss_run(
@@ -111,12 +106,6 @@ def oss_run(
     else:
         out_dir = str(Path(parsed_log_dir).absolute())
     print_parsed_files_summary(out_dir)
-
-
-def unified_parse_from_cli():
-    parser = init_parser()
-    args = parser.parse_args()
-    return unified_parse(**vars(args))
 
 
 def unified_parse(


### PR DESCRIPTION
Introduce output path determination utility and integrate it to standardize where reproducer artifacts land.

- **Utility**: `reproducer/utils.py::determine_output_paths(out_dir, kernel_name)`
  - Creates `<out_dir>/<kernel_name>/` if needed and returns timestamped paths for the output script and context JSON (e.g., `repro_YYYYMMDDHHMMSS.py`, `repro_context_YYYYMMDDHHMMSS.json`).
  - Ensures multiple reproductions of the same kernel are kept separate and discoverable by time.

- **Integration**:
  - `reproducer/orchestrator.py` calls `determine_output_paths(...)` right after building the context bundle to set up destinations before code emission.
  - CLI default `--out-dir` is set to `repro_output` to keep generated artifacts grouped under a predictable root.

- Change stats: 3 files changed, 28 insertions(+), 1 deletion(-)
- Files changed: `tritonparse/reproducer/utils.py`; `tritonparse/reproducer/orchestrator.py`; `tritonparse/reproducer/cli.py`