### PR TITLE
[Feature] Add SASS disassembly support and expose toggle in structured logging

### DIFF
--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -10,6 +10,7 @@ import json
 import logging
 import math
 import os
+import subprocess
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
@@ -41,6 +42,14 @@ TRITONPARSE_KERNEL_ALLOWLIST = os.environ.get("TRITONPARSE_KERNEL_ALLOWLIST", No
 _KERNEL_ALLOWLIST_PATTERNS: Optional[List[str]] = None
 # Enable launch trace. WARNNING: it will overwrite launch_metadata function for each triton kernel.
 TRITON_TRACE_LAUNCH = os.getenv("TRITON_TRACE_LAUNCH", None) in ["1", "true", "True"]
+# Enable NVIDIA SASS dump. It requires the CUBIN file to be localable.
+# WARNNING: it will slow down the compilation significantly.
+TRITONPARSE_DUMP_SASS = os.getenv("TRITONPARSE_DUMP_SASS", None) in [
+    "1",
+    "true",
+    "True",
+]
+
 # The flag to mark if launch is traced. It is used to avoid initilizing the launch hook twice.
 _trace_launch_enabled = False
 
@@ -466,6 +475,26 @@ def extract_file_content(trace_data: Dict[str, Any], metadata_group: Dict[str, s
                 message = f"<error reading file: {str(e)}>"
                 trace_data["file_content"][ir_filename] = message
                 log.debug(f"Error reading file {file_path}: {e}")
+    cubin_keys = [key for key in metadata_group.keys() if key.endswith(".cubin")]
+    cubin_path = metadata_group[cubin_keys[0]] if cubin_keys else None
+
+    if TRITONPARSE_DUMP_SASS and cubin_path:
+        filename_no_ext = os.path.splitext(os.path.basename(cubin_path))[0]
+        sass_filename = f"{filename_no_ext}.sass"
+        try:
+            import tritonparse.tools.disasm
+
+            sass_content = tritonparse.tools.disasm.extract(cubin_path)
+            trace_data["file_content"][sass_filename] = sass_content
+        except subprocess.CalledProcessError as e:
+            message = f"<nvdisasm failed: {str(e)}>"
+            trace_data["file_content"][sass_filename] = message
+        except OSError as e:
+            message = f"<error reading cubin file: {str(e)}>"
+            trace_data["file_content"][sass_filename] = message
+        except Exception as e:
+            message = f"<error dumping SASS: {str(e)}>"
+            trace_data["file_content"][sass_filename] = message
 
 
 def extract_metadata_from_src(trace_data, src):
@@ -1068,7 +1097,7 @@ def init_basic(trace_folder: Optional[str] = None):
     """
     Initialize the basic logging system for Triton compilation.
 
-    This function sets up the basic logging system for Triton kernel compilation,
+    This function sets up the basic logging system for Triton kernel compilation.
 
     Args:
         trace_folder (Optional[str]): The folder to store the trace files.
@@ -1097,17 +1126,24 @@ def init_basic(trace_folder: Optional[str] = None):
     maybe_enable_trace_launch()
 
 
-def init(trace_folder: Optional[str] = None, enable_trace_launch: bool = False):
+def init(
+    trace_folder: Optional[str] = None,
+    enable_trace_launch: bool = False,
+    enable_sass_dump: Optional[bool] = None,
+):
     """
-    This function is a wrapper around init_basic() that also sets up the compilation listener.
+    This function is a wrapper around init_basic() that also sets up the compilation listener. Its arguments have higher priority than the environment variables for same settings.
 
     Args:
         trace_folder (Optional[str]): The folder to store the trace files.
         enable_trace_launch (bool): Whether to enable the trace launch hook.
+        enable_sass_dump (Optional[bool]): Whether to enable SASS dumping. If None, uses environment variable.
     """
-    global TRITON_TRACE_LAUNCH
+    global TRITON_TRACE_LAUNCH, TRITONPARSE_DUMP_SASS
     if enable_trace_launch:
         TRITON_TRACE_LAUNCH = True
+    if enable_sass_dump is not None:
+        TRITONPARSE_DUMP_SASS = enable_sass_dump
 
     init_basic(trace_folder)
     from triton import knobs

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -1129,7 +1129,7 @@ def init_basic(trace_folder: Optional[str] = None):
 def init(
     trace_folder: Optional[str] = None,
     enable_trace_launch: bool = False,
-    enable_sass_dump: Optional[bool] = None,
+    enable_sass_dump: Optional[bool] = False,
 ):
     """
     This function is a wrapper around init_basic() that also sets up the compilation listener. Its arguments have higher priority than the environment variables for same settings.
@@ -1137,12 +1137,12 @@ def init(
     Args:
         trace_folder (Optional[str]): The folder to store the trace files.
         enable_trace_launch (bool): Whether to enable the trace launch hook.
-        enable_sass_dump (Optional[bool]): Whether to enable SASS dumping. If None, uses environment variable.
+        enable_sass_dump (Optional[bool]): Whether to enable SASS dumping.
     """
     global TRITON_TRACE_LAUNCH, TRITONPARSE_DUMP_SASS
     if enable_trace_launch:
         TRITON_TRACE_LAUNCH = True
-    if enable_sass_dump is not None:
+    if enable_sass_dump:
         TRITONPARSE_DUMP_SASS = enable_sass_dump
 
     init_basic(trace_folder)

--- a/tritonparse/tools/disasm.py
+++ b/tritonparse/tools/disasm.py
@@ -1,0 +1,71 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+import re
+import subprocess
+
+# Regex patterns for nvdisasm output
+NVDISASM_FNAME_RE = re.compile(r"^\s*\.global\s+(\w+)")
+
+
+def path_to_nvdisasm():
+    from triton import knobs
+
+    return knobs.nvidia.nvdisasm.path
+
+
+def extract(file_path):
+    """Extract SASS from CUBIN using nvdisasm.
+
+    nvdisasm output is much cleaner than cuobjdump:
+    - Single line per instruction (no encoding lines)
+    - Labels are already symbolized (.L_x_0 instead of addresses)
+    - Source line information is included
+    - No need for complex address remapping
+
+    nvdisasm Documentation:
+    https://docs.nvidia.com/cuda/cuda-binary-utilities/index.html
+    """
+    nvdisasm = path_to_nvdisasm()
+    args = [nvdisasm, "-c", "-gp", "-g", "-gi", file_path]
+    sass_str = subprocess.check_output(args)
+    sass_lines = sass_str.splitlines()
+    line_idx = 0
+
+    while line_idx < len(sass_lines):
+        line = sass_lines[line_idx].decode()
+
+        # Find function definition (.global function_name)
+        while NVDISASM_FNAME_RE.match(line) is None:
+            line_idx += 1
+            if line_idx >= len(sass_lines):
+                return None
+            line = sass_lines[line_idx].decode()
+
+        # Extract function name
+        match = NVDISASM_FNAME_RE.match(line)
+        if match is None:
+            return None
+        fname = match.group(1)
+        ret = f"Function:{fname}\n"
+
+        # Find the actual start of function content (.text.kernel_name:)
+        text_section_pattern = f".text.{fname}:"
+        line_idx += 1
+        while line_idx < len(sass_lines):
+            line = sass_lines[line_idx].decode().strip()
+            if line == text_section_pattern:
+                line_idx += 1  # Move past the .text.kernel_name: line
+                break
+            line_idx += 1
+
+        # Process all lines until next .headerflags or end of file
+        while line_idx < len(sass_lines):
+            line = sass_lines[line_idx].decode().rstrip()
+
+            # Stop if we encounter next function's headerflags
+            if line.strip().startswith(".headerflags"):
+                break
+            ret += line + "\n"
+            line_idx += 1
+
+        ret += "\n"
+        return ret


### PR DESCRIPTION
## Summary

Fix https://github.com/meta-pytorch/tritonparse/issues/53 
This PR introduces optional NVIDIA SASS disassembly during Triton compilation tracing and exposes a user-facing toggle. The feature helps debugging and performance analysis by attaching human-readable SASS to trace artifacts when a cubin is available.

## Key changes
- Add new tool: `tritonparse/tools/disasm.py` to extract SASS from CUBIN via `nvdisasm`.
- Integrate SASS extraction into `tritonparse/structured_logging.py` behind an opt-in flag.
- Introduce environment variable `TRITONPARSE_DUMP_SASS` and a higher-priority API argument `enable_sass_dump` to control behavior.

## Implementation details
- `structured_logging.py`:
  - Import `subprocess` and wire `TRITONPARSE_DUMP_SASS` env flag.
  - During `extract_file_content(...)\), if enabled and a `.cubin` path is present in metadata, invoke disassembler and attach `<kernel>.sass` content to `trace_data['file_content']`.
  - Robust error handling for `subprocess.CalledProcessError`, `OSError`, and generic exceptions; writes a short marker message instead of failing the trace.
  - Expand `init(...)` signature to accept `enable_sass_dump: Optional[bool]`; when provided, it overrides the env var (same precedence model as `enable_trace_launch`).
  - Minor docstring correction in `init_basic(...)`.
- `tools/disasm.py`:
  - Resolve `nvdisasm` path via Triton `knobs` and execute `nvdisasm -c -gp -g -gi <cubin>`.
  - Parse output to find function blocks and return a formatted single-function SASS listing (labels preserved, source mapping retained).

## Flags and usage
- Env: set `TRITONPARSE_DUMP_SASS=1` to enable globally.
- API: call `structured_logging.init(..., enable_sass_dump=True)` to force-enable per process/session.
- If both are set, the API argument takes precedence.

## Notes
- Requires NVIDIA CUDA Binary Utilities: `nvdisasm` must be available (as resolved via Triton knobs).
- Disassembly can slow down compilation/trace capture; the feature is intentionally opt-in.

## Diff stats (vs origin/main)
- 2 files changed, 111 insertions(+), 4 deletions(-)
- Modified: `tritonparse/structured_logging.py`
- Added: `tritonparse/tools/disasm.py`
