### PR TITLE
Enhanced Context Manager and Split Inductor Compilations

### DIFF
--- a/tritonparse/common.py
+++ b/tritonparse/common.py
@@ -262,6 +262,7 @@ def parse_logs(
     rank_config: RankConfig,
     verbose: bool = False,
     tritonparse_url_prefix: str = "",
+    split_inductor_compilations: bool = True,
 ) -> Tuple[str, dict]:
     """
     Parse logs.
@@ -271,7 +272,9 @@ def parse_logs(
         rank_config: Rank configuration
         verbose: Whether to print verbose information
         tritonparse_url_prefix: URL prefix for the generated file mapping
-
+        split_inductor_compilations: Whether to split
+            output files by frame_id, compile_id, attempt_id, and compiled_autograd_id.
+            Defaults to True. This rule follows tlparse's behavior.
     Returns:
         Tuple of (parsed log directory, file mapping)
     """
@@ -327,7 +330,7 @@ def parse_logs(
                 relative_path = rank.to_string("")
             output_dir = os.path.join(parsed_log_dir, relative_path)
             # Parse the file
-            parse_single_file(input_file, output_dir)
+            parse_single_file(input_file, output_dir, split_inductor_compilations)
             # Collect generated files after parsing and gzip them immediately
             if os.path.exists(output_dir):
                 generated_files = []

--- a/tritonparse/context_manager.py
+++ b/tritonparse/context_manager.py
@@ -11,13 +11,38 @@ def createUniqueTempDirectory():
 
 
 class TritonParseManager:
+    def __init__(
+        self,
+        enable_trace_launch=False,
+        split_inductor_compilations=True,
+        **parse_kwargs,
+    ):
+        """
+        Context manager for tritonparse workflow.
+
+        Args:
+            enable_trace_launch: Whether to enable trace launch
+            split_inductor_compilations: Whether to split inductor compilations in the output
+            **parse_kwargs: Additional keyword arguments to pass to unified_parse
+        """
+        self.enable_trace_launch = enable_trace_launch
+        self.split_inductor_compilations = split_inductor_compilations
+        self.parse_kwargs = parse_kwargs
+        self.dir_path = None
+        self.output_link = None
+
     def __enter__(self):
         self.dir_path = createUniqueTempDirectory()
-        init(self.dir_path)
+        init(self.dir_path, enable_trace_launch=self.enable_trace_launch)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.output_link = unified_parse(source=self.dir_path, overwrite=True)
+        self.output_link = unified_parse(
+            source=self.dir_path,
+            overwrite=True,
+            split_inductor_compilations=self.split_inductor_compilations,
+            **self.parse_kwargs,
+        )
         clear_logging_config()
         if os.path.exists(self.dir_path):
             shutil.rmtree(self.dir_path)

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -1161,11 +1161,7 @@ def init(
             It only works when enable_trace_launch/TRITON_TRACE_LAUNCH is True.
         enable_sass_dump (Optional[bool]): Whether to enable SASS dumping.
     """
-    global \
-        TRITON_TRACE_LAUNCH, \
-        TRITONPARSE_MORE_TENSOR_INFORMATION, \
-        TORCHINDUCTOR_RUN_JIT_POST_COMPILE_HOOK, \
-        TRITONPARSE_DUMP_SASS
+    global TRITON_TRACE_LAUNCH, TRITONPARSE_MORE_TENSOR_INFORMATION, TORCHINDUCTOR_RUN_JIT_POST_COMPILE_HOOK, TRITONPARSE_DUMP_SASS
     if enable_trace_launch:
         TRITON_TRACE_LAUNCH = True
         TORCHINDUCTOR_RUN_JIT_POST_COMPILE_HOOK = True

--- a/tritonparse/trace_processor.py
+++ b/tritonparse/trace_processor.py
@@ -198,7 +198,7 @@ def parse_single_trace_content(trace_content: str) -> str:
 def parse_single_file(
     file_path: str,
     output_dir: str = None,
-    split_by_frame_id_and_compile_id: bool = True,
+    split_inductor_compilations: bool = True,
 ):
     """
     Process a single file, correctly group events by kernel, and extract mappings.
@@ -210,8 +210,9 @@ def parse_single_file(
     Args:
         file_path (str): The path to the file to be processed.
         output_dir (str, optional): Directory to save the output files.
-        split_by_frame_id_and_compile_id (bool, optional): Whether to split
-            output files by frame_id and compile_id. Defaults to True.
+        split_inductor_compilations (bool, optional): Whether to split
+            output files by frame_id, compile_id, attempt_id, and compiled_autograd_id.
+            Defaults to True. This rule follows tlparse's behavior.
     """
     kernels_by_hash = defaultdict(
         lambda: {"compilation": None, "launches": [], "output_file": None}
@@ -253,7 +254,9 @@ def parse_single_file(
                 if not kernel_hash:
                     continue
 
-                if split_by_frame_id_and_compile_id:
+                # Split inductor compilations into separate files
+                # This rule follows tlparse's behavior.
+                if split_inductor_compilations:
                     pt_info = payload.get("pt_info", {})
                     frame_id = pt_info.get("frame_id")
                     frame_compile_id = pt_info.get("frame_compile_id")

--- a/tritonparse/utils.py
+++ b/tritonparse/utils.py
@@ -59,6 +59,7 @@ def oss_run(
     rank: Optional[int] = None,
     all_ranks: bool = False,
     verbose: bool = False,
+    split_inductor_compilations: bool = True,
 ):
     """
     Main function for tritonparse. It is for OSS only.
@@ -97,7 +98,9 @@ def oss_run(
         # Copy the single file to a temp directory, then parse it
         logs = copy_local_to_tmpdir(local_path, verbose)
 
-    parsed_log_dir, _ = parse_logs(logs, rank_config, verbose)
+    parsed_log_dir, _ = parse_logs(
+        logs, rank_config, verbose, split_inductor_compilations
+    )
     if out is not None:
         save_logs(Path(out), parsed_log_dir, overwrite, verbose)
     # Print beautiful summary of all parsed files
@@ -116,6 +119,7 @@ def unified_parse(
     rank: Optional[int] = None,
     all_ranks: bool = False,
     verbose: bool = False,
+    split_inductor_compilations: bool = True,
     **kwargs,
 ):
     """
@@ -142,6 +146,7 @@ def unified_parse(
         rank=rank,
         all_ranks=all_ranks,
         verbose=verbose,
+        split_inductor_compilations=split_inductor_compilations,
         **kwargs,
     )
     return output


### PR DESCRIPTION

## Overview
This PR enhances the `TritonParseManager` context manager with configurable parameters and adds support for controlling inductor compilation splitting behavior throughout the parsing pipeline.

## Key Changes

### 1. Enhanced Context Manager (`context_manager.py`)
- **Added `__init__` method** with configurable parameters:
  - `enable_trace_launch`: Control whether to enable trace launch logging
  - `split_inductor_compilations`: Control whether to split inductor compilations in output
  - `**parse_kwargs`: Support additional keyword arguments to pass to `unified_parse`
- **Updated `__exit__` method** to pass these parameters through to `unified_parse`
- The context manager now provides more flexibility for different use cases

### 2. Parameter Threading (`utils.py`, `common.py`, `trace_processor.py`)
- **Added `split_inductor_compilations` parameter** to the parsing pipeline:
  - `unified_parse()` → `oss_run()` → `parse_logs()` → `parse_single_file()`
- **Renamed parameter** in `trace_processor.py`:
  - From: `split_by_frame_id_and_compile_id`
  - To: `split_inductor_compilations` (more descriptive and consistent)
- **Updated documentation** to clarify that this behavior follows tlparse's convention

### 3. Comprehensive Testing (`tests/test_tritonparse.py`)
- **Added new test**: `test_context_manager_with_split_compilations`
- **Test coverage includes**:
  - Context manager resource management (temp directory creation/cleanup)
  - Both Triton kernel compilation and inductor compilation (via `torch.compile`)
  - Verification that `split_inductor_compilations=True` vs `False` produces different output file counts
  - Proper cleanup with support for `TEST_KEEP_OUTPUT` environment variable

### 4. Minor Code Quality Improvements
- Code formatting improvements in `structured_logging.py`
- Import statement reorganization in `tests/test_tritonparse.py`

## Behavior Changes

### `split_inductor_compilations=True` (default)
- Splits inductor compilations into separate files based on:
  - `frame_id`
  - `frame_compile_id`
  - `attempt_id`
  - `compiled_autograd_id`
- Results in **more granular output files** (one additional file compared to False)

### `split_inductor_compilations=False`
- Groups all inductor compilations together
- Results in **fewer, consolidated output files**

## Backward Compatibility
- ✅ **Fully backward compatible**: All new parameters have sensible defaults
- ✅ **Default behavior unchanged**: `split_inductor_compilations=True` maintains existing behavior
- ✅ **Existing code works without modification**

## Testing
Run the new test with:
```bash
TORCHINDUCTOR_FX_GRAPH_CACHE=0 python -m unittest tests.test_tritonparse.TestTritonparseCUDA.test_context_manager_with_split_compilations -v
```

## Example Usage

### Basic usage (unchanged):
```python
with TritonParseManager() as manager:
    # Your Triton/PyTorch code here
    pass
```

### New usage with parameters:
```python
with TritonParseManager(
    enable_trace_launch=True,
    split_inductor_compilations=False,
    out="./output_dir"
) as manager:
    # Your Triton/PyTorch code here
    pass
# Output will be automatically parsed and saved to ./output_dir
```

