### PR TITLE
[Feature] Refactor Placeholder Replacement with Extensible Class Design

### DIFF
--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,7 +1,11 @@
 from pathlib import Path
+from typing import Optional
 
 from tritonparse.reproducer.ingestion.ndjson import build_context_bundle
-from tritonparse.reproducer.placeholder_replacer import DefaultPlaceholderReplacer
+from tritonparse.reproducer.placeholder_replacer import (
+    DefaultPlaceholderReplacer,
+    PlaceholderReplacer,
+)
 from tritonparse.reproducer.templates.loader import load_template_code
 from tritonparse.reproducer.utils import determine_output_paths
 
@@ -14,6 +18,7 @@ def reproduce(
     line_index: int,
     out_dir: str,
     template: str,
+    replacer: Optional[PlaceholderReplacer] = None,
 ) -> dict[str, Path]:
     """
     Generate a reproducer script from NDJSON trace file.
@@ -22,6 +27,8 @@ def reproduce(
         input_path: Path to the NDJSON trace file.
         line_index: Line index of the launch event to reproduce.
         out_dir: Output directory for reproducer files.
+        template: Template name to use for the reproducer.
+        replacer: Optional custom PlaceholderReplacer instance. If None, uses DefaultPlaceholderReplacer.
     """
     logger.debug(f"Building bundle from {input_path} at line {line_index}")
     events = load_ndjson(Path(input_path))
@@ -40,7 +47,9 @@ def reproduce(
     template_code = load_template_code(template)
 
     # Use PlaceholderReplacer to replace all placeholders
-    replacer = DefaultPlaceholderReplacer()
+    # If no custom replacer provided, use the default one
+    if replacer is None:
+        replacer = DefaultPlaceholderReplacer()
     final_code = replacer.replace(
         template_code, context_bundle, temp_json_path=temp_json_path
     )

--- a/tritonparse/reproducer/orchestrator.py
+++ b/tritonparse/reproducer/orchestrator.py
@@ -1,13 +1,9 @@
 from pathlib import Path
 
 from tritonparse.reproducer.ingestion.ndjson import build_context_bundle
+from tritonparse.reproducer.placeholder_replacer import DefaultPlaceholderReplacer
 from tritonparse.reproducer.templates.loader import load_template_code
-from tritonparse.reproducer.utils import (
-    _generate_import_statements,
-    _generate_invocation_snippet,
-    _parse_kernel_signature,
-    determine_output_paths,
-)
+from tritonparse.reproducer.utils import determine_output_paths
 
 from tritonparse.tools.prettify_ndjson import load_ndjson, save_prettified_json
 from tritonparse.tp_logger import logger
@@ -42,18 +38,13 @@ def reproduce(
     save_prettified_json(context_bundle.raw_launch_event, temp_json_path)
     logger.debug("Loading reproducer template.")
     template_code = load_template_code(template)
-    final_code = template_code.replace(
-        "{{JSON_FILE_NAME_PLACEHOLDER}}", temp_json_path.name
+
+    # Use PlaceholderReplacer to replace all placeholders
+    replacer = DefaultPlaceholderReplacer()
+    final_code = replacer.replace(
+        template_code, context_bundle, temp_json_path=temp_json_path
     )
-    sys_stmt, import_statement = _generate_import_statements(context_bundle.kernel_info)
-    final_code = final_code.replace("# {{KERNEL_SYSPATH_PLACEHOLDER}}", sys_stmt)
-    final_code = final_code.replace("# {{KERNEL_IMPORT_PLACEHOLDER}}", import_statement)
-    source_code = context_bundle.kernel_info.source_code
-    pos_args, kw_args = _parse_kernel_signature(source_code)
-    invocation_snippet = _generate_invocation_snippet(pos_args, kw_args)
-    final_code = final_code.replace(
-        "# {{KERNEL_INVOCATION_PLACEHOLDER}}", invocation_snippet
-    )
+
     out_py_path.write_text(final_code, encoding="utf-8")
 
     filepath = context_bundle.kernel_info.file_path

--- a/tritonparse/reproducer/placeholder_replacer.py
+++ b/tritonparse/reproducer/placeholder_replacer.py
@@ -1,0 +1,110 @@
+from abc import ABC
+from typing import Any, Callable, Dict
+
+from tritonparse.reproducer.ingestion.ndjson import ContextBundle
+from tritonparse.reproducer.utils import (
+    _generate_import_statements,
+    _generate_invocation_snippet,
+    _parse_kernel_signature,
+)
+
+
+class PlaceholderReplacer(ABC):
+    """
+    Abstract base class for template placeholder replacement.
+
+    Subclasses should register replacement handlers in their __init__ method
+    by calling self.register(placeholder, handler_function).
+
+    Each handler function should have the signature:
+        handler(code: str, context_bundle: ContextBundle, **kwargs) -> str
+    """
+
+    def __init__(self):
+        # Dictionary mapping placeholder strings to handler functions
+        self.handlers: Dict[str, Callable[[str, ContextBundle, Any], str]] = {}
+
+    def register(
+        self, placeholder: str, handler: Callable[[str, ContextBundle, Any], str]
+    ):
+        """
+        Register a handler function for a specific placeholder.
+
+        Args:
+            placeholder: The placeholder string to replace (e.g., "{{JSON_FILE_NAME_PLACEHOLDER}}")
+            handler: A callable that takes (code, context_bundle, **kwargs) and returns modified code
+        """
+        self.handlers[placeholder] = handler
+
+    def replace(
+        self, template_code: str, context_bundle: ContextBundle, **kwargs
+    ) -> str:
+        """
+        Replace all registered placeholders in the template code.
+
+        Args:
+            template_code: The template code containing placeholders
+            context_bundle: Context information about the kernel
+            **kwargs: Additional keyword arguments passed to handler functions
+
+        Returns:
+            The code with all placeholders replaced
+        """
+        code = template_code
+        for placeholder, handler in self.handlers.items():
+            code = handler(code, context_bundle, **kwargs)
+        return code
+
+
+class DefaultPlaceholderReplacer(PlaceholderReplacer):
+    """
+    Default implementation of PlaceholderReplacer.
+
+    Handles the following placeholders:
+    - {{JSON_FILE_NAME_PLACEHOLDER}}: Replaced with the JSON file name
+    - # {{KERNEL_SYSPATH_PLACEHOLDER}}: Replaced with sys.path setup code
+    - # {{KERNEL_IMPORT_PLACEHOLDER}}: Replaced with kernel import statement
+    - # {{KERNEL_INVOCATION_PLACEHOLDER}}: Replaced with kernel invocation code
+    """
+
+    def __init__(self):
+        super().__init__()
+        # Register all default handlers
+        self.register("{{JSON_FILE_NAME_PLACEHOLDER}}", self._replace_json_filename)
+        self.register("# {{KERNEL_SYSPATH_PLACEHOLDER}}", self._replace_kernel_syspath)
+        self.register("# {{KERNEL_IMPORT_PLACEHOLDER}}", self._replace_kernel_import)
+        self.register(
+            "# {{KERNEL_INVOCATION_PLACEHOLDER}}", self._replace_kernel_invocation
+        )
+
+    def _replace_json_filename(
+        self, code: str, context_bundle: ContextBundle, **kwargs
+    ) -> str:
+        """Replace the JSON file name placeholder."""
+        temp_json_path = kwargs.get("temp_json_path")
+        if temp_json_path is None:
+            raise ValueError("temp_json_path is required for JSON filename replacement")
+        return code.replace("{{JSON_FILE_NAME_PLACEHOLDER}}", temp_json_path.name)
+
+    def _replace_kernel_syspath(
+        self, code: str, context_bundle: ContextBundle, **kwargs
+    ) -> str:
+        """Replace the kernel sys.path placeholder."""
+        sys_stmt, _ = _generate_import_statements(context_bundle.kernel_info)
+        return code.replace("# {{KERNEL_SYSPATH_PLACEHOLDER}}", sys_stmt)
+
+    def _replace_kernel_import(
+        self, code: str, context_bundle: ContextBundle, **kwargs
+    ) -> str:
+        """Replace the kernel import placeholder."""
+        _, import_statement = _generate_import_statements(context_bundle.kernel_info)
+        return code.replace("# {{KERNEL_IMPORT_PLACEHOLDER}}", import_statement)
+
+    def _replace_kernel_invocation(
+        self, code: str, context_bundle: ContextBundle, **kwargs
+    ) -> str:
+        """Replace the kernel invocation placeholder."""
+        source_code = context_bundle.kernel_info.source_code
+        pos_args, kw_args = _parse_kernel_signature(source_code)
+        invocation_snippet = _generate_invocation_snippet(pos_args, kw_args)
+        return code.replace("# {{KERNEL_INVOCATION_PLACEHOLDER}}", invocation_snippet)


### PR DESCRIPTION
## Overview

This PR refactors the placeholder replacement logic in the reproducer orchestrator by extracting it into an extensible class-based design. The change makes the code more modular, maintainable, and allows users to easily customize placeholder replacement behavior.

## Changes

### 1. Created `placeholder_replacer.py` Module

Added a new module containing two classes:

#### `PlaceholderReplacer` (Abstract Base Class)
- Defines the interface for placeholder replacement strategies
- Uses a registration pattern where handlers are mapped to specific placeholders
- Provides `register()` method to register handler functions
- Implements `replace()` template method that iterates through all registered handlers

#### `DefaultPlaceholderReplacer` (Concrete Implementation)
- Implements the default placeholder replacement logic previously hardcoded in `orchestrator.py`
- Registers four handlers in `__init__`:
  - `_replace_json_filename`: Replaces `{{JSON_FILE_NAME_PLACEHOLDER}}`
  - `_replace_kernel_syspath`: Replaces `# {{KERNEL_SYSPATH_PLACEHOLDER}}`
  - `_replace_kernel_import`: Replaces `# {{KERNEL_IMPORT_PLACEHOLDER}}`
  - `_replace_kernel_invocation`: Replaces `# {{KERNEL_INVOCATION_PLACEHOLDER}}`

### 2. Refactored `orchestrator.py`

- Removed hardcoded placeholder replacement logic (previously 13 lines of sequential `.replace()` calls)
- Added optional `replacer` parameter to `reproduce()` function, allowing users to pass custom replacers
- If no custom replacer is provided, defaults to `DefaultPlaceholderReplacer`
- Reduced code complexity and improved readability
- Removed unused imports: `_generate_import_statements`, `_generate_invocation_snippet`, `_parse_kernel_signature`

## API Usage

### Using Default Replacer (Backward Compatible)
```python
# No replacer specified - uses DefaultPlaceholderReplacer automatically
result = reproduce(
    input_path="trace.ndjson",
    line_index=0,
    out_dir="output/",
    template="example"
)
```

### Using Custom Replacer
```python
custom_replacer = CustomPlaceholderReplacer()
result = reproduce(
    input_path="trace.ndjson",
    line_index=0,
    out_dir="output/",
    template="example",
    replacer=custom_replacer  # Inject custom behavior
)
```

## Benefits

### 1. **Extensibility**
Users can now easily create custom replacers by inheriting from `PlaceholderReplacer`:

```python
from tritonparse.reproducer.placeholder_replacer import PlaceholderReplacer
from tritonparse.reproducer.orchestrator import reproduce

class CustomPlaceholderReplacer(PlaceholderReplacer):
    def __init__(self):
        super().__init__()
        # Register custom handlers
        self.register("{{MY_PLACEHOLDER}}", self._my_handler)
    
    def _my_handler(self, code, context_bundle, **kwargs):
        return code.replace("{{MY_PLACEHOLDER}}", "custom_value")

# Use custom replacer
custom_replacer = CustomPlaceholderReplacer()
result = reproduce(
    input_path="trace.ndjson",
    line_index=0,
    out_dir="output/",
    template="example",
    replacer=custom_replacer  # Pass custom replacer
)
```

### 2. **Maintainability**
- Each placeholder has its own dedicated handler method
- Single Responsibility Principle: each handler does one thing
- Clear separation of concerns between orchestration and replacement logic

### 3. **Flexibility**
- Users can selectively override specific handlers
- Easy to add new placeholders without modifying existing code
- Handler functions receive `**kwargs` for future extensibility

### 4. **Testability**
- Replacement logic can now be tested independently of the orchestrator
- Each handler can be unit tested in isolation

## Design Patterns

This implementation follows multiple design patterns:

### Strategy Pattern + Template Method Pattern
- `PlaceholderReplacer` defines the template method `replace()`
- Concrete implementations provide specific strategies via registered handlers
- The registration mechanism provides flexibility in composing behaviors

### Dependency Injection
- The `reproduce()` function accepts a `PlaceholderReplacer` as an optional parameter
- Allows runtime injection of custom behavior without modifying the orchestrator
- Follows the Dependency Inversion Principle: depends on abstraction (`PlaceholderReplacer`) not concrete implementation

## Backward Compatibility

✅ This refactoring is **fully backward compatible**:
- The `reproduce()` function accepts an optional `replacer` parameter (defaults to `None`)
- Existing code that calls `reproduce()` without the `replacer` parameter continues to work unchanged
- Output behavior is identical to the previous implementation when using the default replacer
- No breaking changes for existing users of the reproducer API


