### PR TITLE
Bug Fixes for TritonParse

### DIFF
--- a/tests/test_tritonparse.py
+++ b/tests/test_tritonparse.py
@@ -616,7 +616,8 @@ class TestTritonparseCUDA(unittest.TestCase):
         output_files_split_true = sorted(os.listdir(temp_output_dir_split_true))
         num_files_split_true = len(output_files_split_true)
         print(f"Output files (split=True): {num_files_split_true} files")
-        print(f"  Files: {output_files_split_true}")
+        for f in output_files_split_true:
+            print(f"  - {f}")
 
         # === Clear caches between tests ===
         second_test_cache_dir, original_cache_dir = clear_all_caches(add_kernel)
@@ -656,7 +657,8 @@ class TestTritonparseCUDA(unittest.TestCase):
         output_files_split_false = sorted(os.listdir(temp_output_dir_split_false))
         num_files_split_false = len(output_files_split_false)
         print(f"Output files (split=False): {num_files_split_false} files")
-        print(f"  Files: {output_files_split_false}")
+        for f in output_files_split_false:
+            print(f"  - {f}")
 
         # Check compilation events in parsed output for split=False
         ndjson_gz_files_split_false = [

--- a/tritonparse/reproducer/placeholder_replacer.py
+++ b/tritonparse/reproducer/placeholder_replacer.py
@@ -57,7 +57,7 @@ class PlaceholderReplacer(ABC):
         """
         code = template_code
         for placeholder, handler in self.handlers.items():
-            code = handler(code, context_bundle)
+            code = handler(code, context_bundle, **kwargs)
         return code
 
 

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -281,7 +281,7 @@ def _log_torch_tensor_info(tensor_value):
             arg_info["mean"] = float_tensor.mean().item()
             arg_info["std"] = float_tensor.std().item()
         except (RuntimeError, ValueError, TypeError) as e:
-            log.debug(f"Unable to compute tensor statistics: {e}")
+            log.warning(f"Unable to compute tensor statistics: {e}")
             arg_info["tensor_capture_error"] = str(e)
     return arg_info
 

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -281,7 +281,7 @@ def _log_torch_tensor_info(tensor_value):
             arg_info["mean"] = float_tensor.mean().item()
             arg_info["std"] = float_tensor.std().item()
         except (RuntimeError, ValueError, TypeError) as e:
-            log.warning(f"Unable to compute tensor statistics: {e}")
+            log.error(f"Unable to compute tensor statistics: {e}")
             arg_info["tensor_capture_error"] = str(e)
     return arg_info
 

--- a/tritonparse/structured_logging.py
+++ b/tritonparse/structured_logging.py
@@ -273,12 +273,15 @@ def _log_torch_tensor_info(tensor_value):
         arg_info["data_ptr"] = hex(tensor_value.data_ptr())
     if TRITONPARSE_MORE_TENSOR_INFORMATION:
         try:
-            arg_info["min"] = tensor_value.min().item()
-            arg_info["max"] = tensor_value.max().item()
-            arg_info["mean"] = tensor_value.float().mean().item()
-            arg_info["std"] = tensor_value.float().std().item()
+            # Convert to float for reliable statistics computation across all dtypes
+            # This creates a new tensor without modifying the original
+            float_tensor = tensor_value.float()
+            arg_info["min"] = float_tensor.min().item()
+            arg_info["max"] = float_tensor.max().item()
+            arg_info["mean"] = float_tensor.mean().item()
+            arg_info["std"] = float_tensor.std().item()
         except (RuntimeError, ValueError, TypeError) as e:
-            log.error(f"Error computing additional tensor statistics: {e}")
+            log.debug(f"Unable to compute tensor statistics: {e}")
             arg_info["tensor_capture_error"] = str(e)
     return arg_info
 

--- a/tritonparse/utils.py
+++ b/tritonparse/utils.py
@@ -99,7 +99,10 @@ def oss_run(
         logs = copy_local_to_tmpdir(local_path, verbose)
 
     parsed_log_dir, _ = parse_logs(
-        logs, rank_config, verbose, split_inductor_compilations
+        logs,
+        rank_config,
+        verbose,
+        split_inductor_compilations=split_inductor_compilations,
     )
     if out is not None:
         save_logs(Path(out), parsed_log_dir, overwrite, verbose)


### PR DESCRIPTION
## Overview
Fixes three critical bugs causing test failures:
1. Reproducer kwargs not forwarded to handlers
2. UInt32 tensor statistics computation crash
3. `split_inductor_compilations` parameter not respected

## Changes

### 1. Fix Reproducer kwargs Propagation
**File**: `tritonparse/reproducer/placeholder_replacer.py`

Added `**kwargs` forwarding to handlers:
```python
code = handler(code, context_bundle, **kwargs)
```
Fixes `ValueError: temp_json_path is required` in `test_reproducer_end_to_end`.

---

### 2. Fix UInt32 Tensor Statistics
**File**: `tritonparse/structured_logging.py`

**Issue**: `"min_all_cuda" not implemented for 'UInt32'` error

**Fix**: Unified float conversion for all tensor statistics:
```python
float_tensor = tensor_value.float()
arg_info["min"] = float_tensor.min().item()
arg_info["max"] = float_tensor.max().item()
arg_info["mean"] = float_tensor.mean().item()
arg_info["std"] = float_tensor.std().item()
```
Also changed log level from `error` to `debug` for failed stats.

---

### 3. Fix split_inductor_compilations Parameter
**File**: `tritonparse/utils.py`

Use explicit keyword argument:
```python
parsed_log_dir, _ = parse_logs(
    logs, rank_config, verbose,
    split_inductor_compilations=split_inductor_compilations,
)
```

---

### 4. Improve Test Debug Output
**File**: `tests/test_tritonparse.py`

Enhanced file listing for easier debugging:
```python
for f in output_files_split_true:
    print(f"  - {f}")
```

---

## Test Coverage
- ✅ Fixes `test_reproducer_end_to_end`
- ✅ Fixes `test_triton_kernels_Tensor` 
- ✅ All existing tests pass

## Files Changed
4 files, 17 insertions(+), 9 deletions(-)
