### PR TITLE
Add unit tests for EnvironmentManager and --auto-setup CLI

### DIFF
--- a/tests/cpu/test_cli_integration.py
+++ b/tests/cpu/test_cli_integration.py
@@ -1,0 +1,143 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""CLI Integration Tests for --auto-env-setup with --llvm-only bisect.
+
+These tests verify that the --auto-env-setup CLI option is correctly integrated
+into the main tritonparse bisect CLI for automatic environment setup.
+"""
+
+import argparse
+import unittest
+
+from tritonparse.bisect.cli import _add_bisect_args
+
+
+class CLIArgumentParsingTest(unittest.TestCase):
+    """Tests for CLI argument parsing."""
+
+    def setUp(self):
+        """Set up test parser."""
+        self.parser = argparse.ArgumentParser()
+        _add_bisect_args(self.parser)
+
+    def test_auto_env_setup_option_exists(self):
+        """Test that --auto-env-setup option is available."""
+        args = self.parser.parse_args(
+            [
+                "--llvm-only",
+                "--auto-env-setup",
+                "--triton-dir",
+                "/tmp/oss-triton",
+                "--good-llvm",
+                "def456",
+                "--bad-llvm",
+                "ghi789",
+                "--test-script",
+                "/tmp/test.py",
+            ]
+        )
+        self.assertTrue(args.auto_env_setup)
+        self.assertTrue(args.llvm_only)
+
+    def test_auto_env_setup_requires_llvm_only(self):
+        """Test that --auto-env-setup is intended for use with --llvm-only."""
+        # --auto-env-setup can be parsed without --llvm-only, but the help text
+        # indicates it should be used with --llvm-only. The validation happens
+        # at runtime in _handle_llvm_only.
+        args = self.parser.parse_args(["--auto-env-setup"])
+        self.assertTrue(args.auto_env_setup)
+
+    def test_llvm_only_with_auto_env_setup_and_triton_dir(self):
+        """Test --llvm-only with --auto-env-setup and --triton-dir."""
+        args = self.parser.parse_args(
+            [
+                "--llvm-only",
+                "--auto-env-setup",
+                "--triton-dir",
+                "~/oss-triton",
+                "--good-llvm",
+                "abc123",
+                "--bad-llvm",
+                "def456",
+                "--test-script",
+                "/tmp/test.py",
+            ]
+        )
+        self.assertTrue(args.llvm_only)
+        self.assertTrue(args.auto_env_setup)
+        self.assertEqual(args.triton_dir, "~/oss-triton")
+        self.assertEqual(args.good_llvm, "abc123")
+        self.assertEqual(args.bad_llvm, "def456")
+
+    def test_llvm_only_without_auto_env_setup(self):
+        """Test --llvm-only can still be used without --auto-env-setup."""
+        args = self.parser.parse_args(
+            [
+                "--llvm-only",
+                "--triton-dir",
+                "/existing/triton",
+                "--good-llvm",
+                "abc123",
+                "--bad-llvm",
+                "def456",
+                "--test-script",
+                "/tmp/test.py",
+            ]
+        )
+        self.assertTrue(args.llvm_only)
+        self.assertFalse(args.auto_env_setup)
+
+    def test_fb_llvm_bisect_option_removed(self):
+        """Test that --fb-llvm-bisect option no longer exists."""
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["--fb-llvm-bisect"])
+
+
+class CLIAutoSetupIntegrationTest(unittest.TestCase):
+    """Tests for --auto-env-setup integration with --llvm-only."""
+
+    def setUp(self):
+        """Set up test parser."""
+        self.parser = argparse.ArgumentParser()
+        _add_bisect_args(self.parser)
+
+    def test_auto_env_setup_with_conda_env(self):
+        """Test --auto-env-setup with custom --conda-env."""
+        args = self.parser.parse_args(
+            [
+                "--llvm-only",
+                "--auto-env-setup",
+                "--triton-dir",
+                "~/oss-triton",
+                "--conda-env",
+                "my_custom_env",
+                "--good-llvm",
+                "abc123",
+                "--bad-llvm",
+                "def456",
+                "--test-script",
+                "/tmp/test.py",
+            ]
+        )
+        self.assertEqual(args.conda_env, "my_custom_env")
+
+    def test_default_conda_env(self):
+        """Test default --conda-env value."""
+        args = self.parser.parse_args(
+            [
+                "--llvm-only",
+                "--triton-dir",
+                "~/oss-triton",
+                "--good-llvm",
+                "abc123",
+                "--bad-llvm",
+                "def456",
+                "--test-script",
+                "/tmp/test.py",
+            ]
+        )
+        self.assertEqual(args.conda_env, "triton_bisect")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cpu/test_env_manager.py
+++ b/tests/cpu/test_env_manager.py
@@ -1,0 +1,321 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Tests for EnvironmentManager (CPU-only, no GPU required)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+class EnvironmentManagerTest(unittest.TestCase):
+    """Tests for EnvironmentManager class."""
+
+    def test_init(self):
+        """Test EnvironmentManager initialization."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        triton_dir = Path("/tmp/oss-triton")
+        mock_logger = MagicMock()
+        manager = EnvironmentManager(triton_dir, mock_logger)
+        self.assertEqual(manager.triton_dir, triton_dir)
+        self.assertEqual(manager.llvm_dir, triton_dir / "llvm-project")
+
+    def test_repo_urls(self):
+        """Test that repository URLs are correctly set."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        mock_logger = MagicMock()
+        manager = EnvironmentManager(Path("/tmp/oss-triton"), mock_logger)
+        self.assertEqual(manager.TRITON_REPO, "https://github.com/triton-lang/triton")
+        self.assertEqual(manager.LLVM_REPO, "https://github.com/llvm/llvm-project")
+
+    def test_check_environment_status_nothing_exists(self):
+        """Test status check when nothing exists."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Use a non-existent subdirectory
+            triton_dir = Path(tmpdir) / "nonexistent"
+
+            mock_logger = MagicMock()
+            manager = EnvironmentManager(triton_dir, mock_logger)
+
+            # Mock executor.run_command to return failure for git and success for conda
+            def mock_run_command(cmd, cwd=None):
+                result = MagicMock()
+                if cmd[0] == "conda":
+                    result.success = True
+                else:
+                    result.success = False
+                result.stdout = ""
+                return result
+
+            manager.executor.run_command = mock_run_command
+            status = manager.check_environment_status()
+
+            self.assertFalse(status["triton_exists"])
+            self.assertFalse(status["triton_is_valid_repo"])
+            self.assertFalse(status["llvm_exists"])
+            self.assertFalse(status["llvm_is_valid_repo"])
+            # conda_available depends on mock, should be True
+            self.assertTrue(status["conda_available"])
+
+    def test_check_environment_status_dirs_exist_but_not_valid_repos(self):
+        """Test status check when directories exist but aren't valid git repos."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            triton_dir = Path(tmpdir)
+            llvm_dir = triton_dir / "llvm-project"
+            llvm_dir.mkdir()
+
+            mock_logger = MagicMock()
+            manager = EnvironmentManager(triton_dir, mock_logger)
+
+            # Mock executor.run_command - git rev-parse fails (not valid repos)
+            def mock_run_command(cmd, cwd=None):
+                result = MagicMock()
+                if cmd[0] == "conda":
+                    result.success = True
+                elif cmd == ["git", "rev-parse", "HEAD"]:
+                    # Not a valid git repo
+                    result.success = False
+                else:
+                    result.success = False
+                result.stdout = ""
+                return result
+
+            manager.executor.run_command = mock_run_command
+            status = manager.check_environment_status()
+
+            self.assertTrue(status["triton_exists"])
+            self.assertFalse(status["triton_is_valid_repo"])
+            self.assertTrue(status["llvm_exists"])
+            self.assertFalse(status["llvm_is_valid_repo"])
+
+    def test_check_environment_status_valid_git_repos(self):
+        """Test status check when directories are valid git repos."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            triton_dir = Path(tmpdir)
+            llvm_dir = triton_dir / "llvm-project"
+            llvm_dir.mkdir()
+
+            mock_logger = MagicMock()
+            manager = EnvironmentManager(triton_dir, mock_logger)
+
+            # Mock executor.run_command - git rev-parse succeeds (valid repos)
+            def mock_run_command(cmd, cwd=None):
+                result = MagicMock()
+                if cmd[0] == "conda":
+                    result.success = True
+                elif cmd == ["git", "rev-parse", "HEAD"]:
+                    # Valid git repo
+                    result.success = True
+                    result.stdout = "abc123def456\n"
+                else:
+                    result.success = True
+                result.stdout = getattr(result, "stdout", "")
+                return result
+
+            manager.executor.run_command = mock_run_command
+            status = manager.check_environment_status()
+
+            self.assertTrue(status["triton_exists"])
+            self.assertTrue(status["triton_is_valid_repo"])
+            self.assertTrue(status["llvm_exists"])
+            self.assertTrue(status["llvm_is_valid_repo"])
+
+    def test_ensure_triton_repo_clone(self):
+        """Test cloning Triton when directory doesn't exist."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            triton_dir = Path(tmpdir) / "nonexistent"
+
+            mock_logger = MagicMock()
+            manager = EnvironmentManager(triton_dir, mock_logger)
+
+            # Track calls to run_command
+            calls = []
+
+            def mock_run_command(cmd, cwd=None):
+                calls.append((cmd, cwd))
+                result = MagicMock()
+                result.success = True
+                result.stdout = "abc123\n"
+                result.stderr = ""
+                return result
+
+            manager.executor.run_command = mock_run_command
+            manager._ensure_triton_repo()
+
+            # ensure_git_repo calls: git clone, then git rev-parse HEAD (verify)
+            self.assertGreaterEqual(len(calls), 2)
+            # First call: git clone
+            cmd, _ = calls[0]
+            self.assertEqual(cmd[0], "git")
+            self.assertEqual(cmd[1], "clone")
+            self.assertIn("triton-lang/triton", cmd[2])
+            # Second call: git rev-parse HEAD (verification)
+            self.assertEqual(calls[1][0], ["git", "rev-parse", "HEAD"])
+
+    def test_ensure_triton_repo_fetch(self):
+        """Test fetching updates when Triton directory exists."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            triton_dir = Path(tmpdir)
+
+            mock_logger = MagicMock()
+            manager = EnvironmentManager(triton_dir, mock_logger)
+
+            # Track calls to run_command
+            calls = []
+
+            def mock_run_command(cmd, cwd=None):
+                calls.append((cmd, cwd))
+                result = MagicMock()
+                result.success = True
+                result.stdout = "abc123\n"
+                result.stderr = ""
+                return result
+
+            manager.executor.run_command = mock_run_command
+            manager._ensure_triton_repo()
+
+            # Should have called git rev-parse HEAD (validation) then git fetch
+            self.assertEqual(len(calls), 2)
+            # First call: git rev-parse HEAD
+            self.assertEqual(calls[0][0], ["git", "rev-parse", "HEAD"])
+            # Second call: git fetch origin
+            self.assertEqual(calls[1][0], ["git", "fetch", "origin"])
+
+    def test_ensure_llvm_repo_clone(self):
+        """Test cloning LLVM when directory doesn't exist."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            triton_dir = Path(tmpdir)
+            # triton_dir exists but llvm_dir doesn't
+
+            mock_logger = MagicMock()
+            manager = EnvironmentManager(triton_dir, mock_logger)
+
+            # Track calls to run_command
+            calls = []
+
+            def mock_run_command(cmd, cwd=None):
+                calls.append((cmd, cwd))
+                result = MagicMock()
+                result.success = True
+                result.stdout = "abc123\n"
+                result.stderr = ""
+                return result
+
+            manager.executor.run_command = mock_run_command
+            manager._ensure_llvm_repo()
+
+            # ensure_git_repo calls: git clone, then git rev-parse HEAD (verify)
+            self.assertGreaterEqual(len(calls), 2)
+            # First call: git clone
+            cmd, _ = calls[0]
+            self.assertEqual(cmd[0], "git")
+            self.assertEqual(cmd[1], "clone")
+            self.assertIn("llvm/llvm-project", cmd[2])
+            # Second call: git rev-parse HEAD (verification)
+            self.assertEqual(calls[1][0], ["git", "rev-parse", "HEAD"])
+
+    def test_ensure_conda_env_not_available(self):
+        """Test error when conda is not available."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        mock_logger = MagicMock()
+        manager = EnvironmentManager(Path("/tmp/oss-triton"), mock_logger)
+
+        def mock_run_command(cmd, cwd=None):
+            result = MagicMock()
+            result.success = False
+            result.stdout = ""
+            result.stderr = "conda: command not found"
+            return result
+
+        manager.executor.run_command = mock_run_command
+
+        with self.assertRaises(RuntimeError) as ctx:
+            manager._ensure_conda_env("test_env")
+        self.assertIn("conda not found", str(ctx.exception))
+
+    def test_ensure_conda_env_exists(self):
+        """Test when conda env already exists."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        mock_logger = MagicMock()
+        manager = EnvironmentManager(Path("/tmp/oss-triton"), mock_logger)
+
+        calls = []
+
+        def mock_run_command(cmd, cwd=None):
+            calls.append(cmd)
+            result = MagicMock()
+            if cmd == ["conda", "--version"]:
+                result.success = True
+                result.stdout = "conda 23.1.0"
+            elif cmd == ["conda", "env", "list"]:
+                result.success = True
+                result.stdout = "base\ntriton_bisect    /path/to/env\n"
+            else:
+                result.success = True
+                result.stdout = ""
+            result.stderr = ""
+            return result
+
+        manager.executor.run_command = mock_run_command
+        manager._ensure_conda_env("triton_bisect")
+
+        # Should only call conda --version and conda env list, not create
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0], ["conda", "--version"])
+        self.assertEqual(calls[1], ["conda", "env", "list"])
+
+    def test_ensure_conda_env_create(self):
+        """Test creating conda env when it doesn't exist."""
+        from tritonparse.bisect.env_manager import EnvironmentManager
+
+        mock_logger = MagicMock()
+        manager = EnvironmentManager(Path("/tmp/oss-triton"), mock_logger)
+
+        calls = []
+
+        def mock_run_command(cmd, cwd=None):
+            calls.append(cmd)
+            result = MagicMock()
+            if cmd == ["conda", "--version"]:
+                result.success = True
+                result.stdout = "conda 23.1.0"
+            elif cmd == ["conda", "env", "list"]:
+                result.success = True
+                result.stdout = "base\nother_env    /path/to/env\n"
+            else:
+                result.success = True
+                result.stdout = ""
+            result.stderr = ""
+            return result
+
+        manager.executor.run_command = mock_run_command
+        manager._ensure_conda_env("triton_bisect")
+
+        # Should call all three commands
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls[0], ["conda", "--version"])
+        self.assertEqual(calls[1], ["conda", "env", "list"])
+        # Third call should be conda create with python=3.12
+        self.assertEqual(calls[2][0], "conda")
+        self.assertEqual(calls[2][1], "create")
+        self.assertIn("python=3.12", calls[2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tritonparse/bisect/__init__.py
+++ b/tritonparse/bisect/__init__.py
@@ -12,6 +12,7 @@ from tritonparse.bisect.commit_detector import (
     CommitDetectorError,
     LLVMBumpInfo,
 )
+from tritonparse.bisect.env_manager import EnvironmentManager
 from tritonparse.bisect.executor import CommandResult, ShellExecutor
 from tritonparse.bisect.llvm_bisector import LLVMBisectError, LLVMBisector
 from tritonparse.bisect.logger import BisectLogger
@@ -44,6 +45,7 @@ __all__ = [
     "CommitDetector",
     "CommitDetectorError",
     "CommitPair",
+    "EnvironmentManager",
     "is_rich_available",
     "LLVMBisectError",
     "LLVMBisector",

--- a/tritonparse/bisect/env_manager.py
+++ b/tritonparse/bisect/env_manager.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Dict
 
 from tritonparse.bisect.executor import ShellExecutor
+from tritonparse.bisect.git_utils import ensure_git_repo, verify_git_repo
 from tritonparse.bisect.logger import BisectLogger
 
 
@@ -75,23 +76,135 @@ class EnvironmentManager:
             subprocess.CalledProcessError: If git or conda commands fail.
             RuntimeError: If conda is not available.
         """
-        # TODO: Phase 2 implementation
-        raise NotImplementedError("Will be implemented in Phase 2")
+        self.logger.info("")
+        self.logger.info("=" * 60)
+        self.logger.info("Setting up environment...")
+        self.logger.info("=" * 60)
+
+        self._ensure_triton_repo()
+        self._ensure_llvm_repo()
+        self._ensure_conda_env(conda_env)
+
+        self.logger.info("")
+        self.logger.info("✅ Environment setup complete!")
+        self.logger.info(f"   Triton: {self.triton_dir}")
+        self.logger.info(f"   LLVM:   {self.llvm_dir}")
+        self.logger.info(f"   Conda:  {conda_env}")
+        self.logger.info("=" * 60)
+        self.logger.info("")
 
     def _ensure_triton_repo(self) -> None:
-        """Clone or update Triton repository."""
-        # TODO: Phase 2 implementation
-        raise NotImplementedError("Will be implemented in Phase 2")
+        """
+        Clone or update Triton repository.
+
+        Behavior:
+        - If directory doesn't exist: git clone
+        - If directory exists but not valid git repo: raise error
+        - If directory exists and is valid: git fetch origin (update remote refs)
+
+        Raises:
+            RuntimeError: If git command fails or repo is invalid.
+        """
+        self.logger.info("")
+        ensure_git_repo(
+            repo_dir=self.triton_dir,
+            repo_url=self.TRITON_REPO,
+            repo_name="Triton",
+            executor=self.executor,
+            logger=self.logger,
+            use_streaming=False,
+            fetch_updates=True,
+        )
 
     def _ensure_llvm_repo(self) -> None:
-        """Clone or update LLVM repository."""
-        # TODO: Phase 2 implementation
-        raise NotImplementedError("Will be implemented in Phase 2")
+        """
+        Clone or update LLVM repository.
+
+        Note: LLVM repo is large (~2GB), first clone may take a while.
+
+        Behavior:
+        - If directory doesn't exist: git clone
+        - If directory exists but not valid git repo: raise error
+        - If directory exists and is valid: git fetch origin (update remote refs)
+
+        Raises:
+            RuntimeError: If git command fails or repo is invalid.
+        """
+        self.logger.info("")
+        self.logger.info(
+            "(This may take a while, LLVM repo is ~2GB)"
+            if not self.llvm_dir.exists()
+            else ""
+        )
+        ensure_git_repo(
+            repo_dir=self.llvm_dir,
+            repo_url=self.LLVM_REPO,
+            repo_name="LLVM",
+            executor=self.executor,
+            logger=self.logger,
+            use_streaming=False,
+            fetch_updates=True,
+        )
 
     def _ensure_conda_env(self, env_name: str) -> None:
-        """Create or verify conda environment."""
-        # TODO: Phase 2 implementation
-        raise NotImplementedError("Will be implemented in Phase 2")
+        """
+        Ensure conda environment exists.
+
+        Behavior:
+        - Check if conda is available
+        - Check if environment exists
+        - If not, create new environment with Python 3.12
+
+        Note: You may need to accept the conda license on first run.
+        Dependencies are installed later when running `make dev-install` in Triton.
+
+        Args:
+            env_name: Name of conda environment.
+
+        Raises:
+            RuntimeError: If conda is not installed.
+        """
+        self.logger.info("")
+        self.logger.info(f"🐍 Checking conda environment: {env_name}")
+
+        # Check if conda is available
+        result = self.executor.run_command(
+            ["conda", "--version"],
+        )
+        if not result.success:
+            raise RuntimeError(
+                "conda not found. Please install miniconda:\n"
+                "  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh\n"
+                "  bash Miniconda3-latest-Linux-x86_64.sh"
+            )
+
+        # Check if environment exists
+        result = self.executor.run_command(
+            ["conda", "env", "list"],
+        )
+
+        # Parse conda env list output to check for exact environment name
+        env_exists = False
+        for line in result.stdout.splitlines():
+            # Each line is like: "env_name    /path/to/env" or "env_name *  /path/to/env"
+            parts = line.split()
+            if parts and parts[0] == env_name:
+                env_exists = True
+                break
+
+        if not env_exists:
+            self.logger.info(f"   Creating conda environment: {env_name}")
+            # Note: You may need to accept the conda license on first run
+            result = self.executor.run_command(
+                ["conda", "create", "-n", env_name, "python=3.12", "-y"],
+            )
+            if not result.success:
+                raise RuntimeError(
+                    f"Failed to create conda environment: {result.stderr}"
+                )
+            self.logger.info(f"   ✅ Conda environment '{env_name}' created")
+        else:
+            self.logger.info(f"   ✅ Conda environment '{env_name}' already exists")
 
     def check_environment_status(self) -> Dict[str, bool]:
         """
@@ -100,15 +213,64 @@ class EnvironmentManager:
         Returns:
             Dictionary containing status of each component:
             - triton_exists: Whether Triton directory exists
-            - triton_is_valid_repo: Whether it's a valid git repo
+            - triton_is_valid_repo: Whether it's a valid git repo (verified via git rev-parse)
             - llvm_exists: Whether LLVM directory exists
-            - llvm_is_valid_repo: Whether it's a valid git repo
+            - llvm_is_valid_repo: Whether it's a valid git repo (verified via git rev-parse)
             - conda_available: Whether conda is available
         """
-        # TODO: Phase 2 implementation
-        raise NotImplementedError("Will be implemented in Phase 2")
+        status: Dict[str, bool] = {}
+
+        # Triton
+        status["triton_exists"] = self.triton_dir.exists()
+        if status["triton_exists"]:
+            is_valid, _ = verify_git_repo(self.triton_dir, self.executor)
+            status["triton_is_valid_repo"] = is_valid
+        else:
+            status["triton_is_valid_repo"] = False
+
+        # LLVM
+        status["llvm_exists"] = self.llvm_dir.exists()
+        if status["llvm_exists"]:
+            is_valid, _ = verify_git_repo(self.llvm_dir, self.executor)
+            status["llvm_is_valid_repo"] = is_valid
+        else:
+            status["llvm_is_valid_repo"] = False
+
+        # Conda
+        result = self.executor.run_command(
+            ["conda", "--version"],
+        )
+        status["conda_available"] = result.success
+
+        return status
 
     def print_status(self) -> None:
         """Print formatted environment status (for CLI --status option)."""
-        # TODO: Phase 2 implementation
-        raise NotImplementedError("Will be implemented in Phase 2")
+        status = self.check_environment_status()
+
+        self.logger.info("")
+        self.logger.info("=" * 60)
+        self.logger.info("Environment Status")
+        self.logger.info("=" * 60)
+        self.logger.info(f"📁 Triton Directory: {self.triton_dir}")
+        self.logger.info(
+            f"   Exists:         {'✅' if status['triton_exists'] else '❌'}"
+        )
+        self.logger.info(
+            f"   Valid Git Repo: {'✅' if status['triton_is_valid_repo'] else '❌'}"
+        )
+
+        self.logger.info(f"📁 LLVM Directory: {self.llvm_dir}")
+        self.logger.info(
+            f"   Exists:         {'✅' if status['llvm_exists'] else '❌'}"
+        )
+        self.logger.info(
+            f"   Valid Git Repo: {'✅' if status['llvm_is_valid_repo'] else '❌'}"
+        )
+
+        self.logger.info("🐍 Conda")
+        self.logger.info(
+            f"   Available:      {'✅' if status['conda_available'] else '❌'}"
+        )
+        self.logger.info("=" * 60)
+        self.logger.info("")

--- a/tritonparse/bisect/env_manager.py
+++ b/tritonparse/bisect/env_manager.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Environment Manager for LLVM bisect.
+
+Manages the setup and maintenance of environment required for LLVM bisect:
+- Triton repository (from GitHub)
+- LLVM repository (from GitHub)
+- Conda environment
+
+This is useful for auto-setup when running bisect from environments that
+don't already have the required repositories cloned.
+
+Usage:
+    With --auto-env-setup flag:
+    tritonparseoss bisect --llvm-only --auto-env-setup \
+        --triton-dir ~/oss-triton \
+        --good-llvm abc123 --bad-llvm def456 \
+        --test-script ~/test.py
+"""
+
+from pathlib import Path
+from typing import Dict
+
+from tritonparse.bisect.executor import ShellExecutor
+from tritonparse.bisect.logger import BisectLogger
+
+
+class EnvironmentManager:
+    """
+    Manages environment for LLVM bisect.
+
+    Responsibilities:
+    - Clone/update Triton repository from GitHub
+    - Clone/update LLVM repository from GitHub
+    - Create/verify conda environment with required dependencies
+
+    Example:
+        >>> logger = BisectLogger("./logs")
+        >>> manager = EnvironmentManager(Path("~/oss-triton"), logger)
+        >>> manager.ensure_environment("triton_bisect")
+    """
+
+    TRITON_REPO = "https://github.com/triton-lang/triton"
+    LLVM_REPO = "https://github.com/llvm/llvm-project"
+
+    def __init__(self, triton_dir: Path, logger: BisectLogger) -> None:
+        """
+        Initialize EnvironmentManager.
+
+        Args:
+            triton_dir: Directory where Triton will be cloned.
+            logger: BisectLogger instance for logging.
+        """
+        self.triton_dir = triton_dir
+        self.llvm_dir = triton_dir / "llvm-project"
+        self.logger = logger
+
+        # Create executor for running commands
+        self.executor = ShellExecutor(self.logger)
+
+    def ensure_environment(self, conda_env: str) -> None:
+        """
+        Ensure environment is properly set up.
+
+        This method:
+        1. Clones or updates Triton repository
+        2. Clones or updates LLVM repository
+        3. Creates or verifies conda environment
+
+        Args:
+            conda_env: Name of conda environment to use.
+
+        Raises:
+            subprocess.CalledProcessError: If git or conda commands fail.
+            RuntimeError: If conda is not available.
+        """
+        # TODO: Phase 2 implementation
+        raise NotImplementedError("Will be implemented in Phase 2")
+
+    def _ensure_triton_repo(self) -> None:
+        """Clone or update Triton repository."""
+        # TODO: Phase 2 implementation
+        raise NotImplementedError("Will be implemented in Phase 2")
+
+    def _ensure_llvm_repo(self) -> None:
+        """Clone or update LLVM repository."""
+        # TODO: Phase 2 implementation
+        raise NotImplementedError("Will be implemented in Phase 2")
+
+    def _ensure_conda_env(self, env_name: str) -> None:
+        """Create or verify conda environment."""
+        # TODO: Phase 2 implementation
+        raise NotImplementedError("Will be implemented in Phase 2")
+
+    def check_environment_status(self) -> Dict[str, bool]:
+        """
+        Check environment status (for diagnostics).
+
+        Returns:
+            Dictionary containing status of each component:
+            - triton_exists: Whether Triton directory exists
+            - triton_is_valid_repo: Whether it's a valid git repo
+            - llvm_exists: Whether LLVM directory exists
+            - llvm_is_valid_repo: Whether it's a valid git repo
+            - conda_available: Whether conda is available
+        """
+        # TODO: Phase 2 implementation
+        raise NotImplementedError("Will be implemented in Phase 2")
+
+    def print_status(self) -> None:
+        """Print formatted environment status (for CLI --status option)."""
+        # TODO: Phase 2 implementation
+        raise NotImplementedError("Will be implemented in Phase 2")

--- a/tritonparse/bisect/git_utils.py
+++ b/tritonparse/bisect/git_utils.py
@@ -1,0 +1,115 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Git utility functions for bisect operations.
+
+This module provides shared helper functions for git repository management
+used by both EnvironmentManager and LLVMBisector.
+"""
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+from tritonparse.bisect.executor import ShellExecutor
+from tritonparse.bisect.logger import BisectLogger
+
+
+def verify_git_repo(
+    repo_dir: Path,
+    executor: ShellExecutor,
+) -> Tuple[bool, str]:
+    """
+    Verify a directory is a valid git repository.
+
+    Args:
+        repo_dir: Path to the repository directory.
+        executor: ShellExecutor instance for running commands.
+
+    Returns:
+        Tuple of (is_valid, current_commit_hash).
+        If not valid, current_commit_hash is empty string.
+    """
+    result = executor.run_command(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(repo_dir),
+    )
+    if result.success:
+        return (True, result.stdout.strip())
+    return (False, "")
+
+
+def ensure_git_repo(
+    repo_dir: Path,
+    repo_url: str,
+    repo_name: str,
+    executor: ShellExecutor,
+    logger: BisectLogger,
+    use_streaming: bool = False,
+    fetch_updates: bool = True,
+    cwd: Optional[Path] = None,
+) -> str:
+    """
+    Clone or verify a git repository.
+
+    This function handles the common pattern of:
+    - If directory doesn't exist: git clone
+    - If directory exists but not valid git repo: raise error
+    - If directory exists and is valid: optionally git fetch origin
+
+    Args:
+        repo_dir: Directory where repo should be located.
+        repo_url: URL to clone from (e.g., "https://github.com/llvm/llvm-project").
+        repo_name: Human-readable name for logging (e.g., "LLVM", "Triton").
+        executor: ShellExecutor instance for running commands.
+        logger: BisectLogger instance for logging.
+        use_streaming: Use streaming output for clone (for large repos).
+        fetch_updates: Whether to fetch updates if repo already exists.
+        cwd: Working directory for clone command (defaults to repo_dir's parent).
+
+    Returns:
+        Current commit hash of the repository.
+
+    Raises:
+        RuntimeError: If repo is invalid or operations fail.
+    """
+    if not repo_dir.exists():
+        logger.info(f"{repo_name} repo not found at {repo_dir}")
+        logger.info(f"Cloning {repo_name} repo from {repo_url}...")
+
+        clone_cmd = ["git", "clone", repo_url, str(repo_dir)]
+        clone_cwd = str(cwd) if cwd else None
+
+        if use_streaming:
+            result = executor.run_command_streaming(clone_cmd, cwd=clone_cwd)
+        else:
+            result = executor.run_command(clone_cmd, cwd=clone_cwd)
+
+        if not result.success:
+            raise RuntimeError(f"Failed to clone {repo_name} repo: {result.stderr}")
+
+        logger.info(f"{repo_name} repo cloned successfully")
+
+    # Verify it's a valid git repository
+    is_valid, current_commit = verify_git_repo(repo_dir, executor)
+
+    if not is_valid:
+        raise RuntimeError(
+            f"{repo_name} directory exists but is not a valid git repository: {repo_dir}\n"
+            f"Please remove it and retry: rm -rf {repo_dir}"
+        )
+
+    logger.info(f"{repo_name} repo verified at: {repo_dir}")
+    logger.info(f"Current {repo_name} commit: {current_commit[:12]}")
+
+    # Optionally fetch updates
+    if fetch_updates and repo_dir.exists():
+        logger.info(f"Fetching {repo_name} updates...")
+        result = executor.run_command(
+            ["git", "fetch", "origin"],
+            cwd=str(repo_dir),
+        )
+        if not result.success:
+            raise RuntimeError(f"Failed to fetch {repo_name} updates: {result.stderr}")
+        logger.info("Fetch complete.")
+
+    return current_commit


### PR DESCRIPTION
Summary:
**Unit Tests (test_env_manager.py):**
- EnvironmentManagerTest: initialization, repo URLs, status checks
- Triton repo clone/fetch tests with mocked executor
- LLVM repo clone/fetch tests with mocked executor
- Conda environment creation/validation tests

**CLI Integration Tests (test_cli_integration.py):**
- CLIArgumentParsingTest: --auto-setup option existence
- Test --auto-setup with --llvm-only and --triton-dir
- Test --llvm-only without --auto-setup still works
- Test --fb-llvm-bisect option no longer exists

Reviewed By: FindHao

Differential Revision: D92068434


