### PR TITLE
Improve format_python_code logging when black/isort unavailable

### DIFF
--- a/tritonparse/reproducer/utils.py
+++ b/tritonparse/reproducer/utils.py
@@ -663,7 +663,10 @@ def format_python_code(code: str) -> str:
         )
         logger.debug("Successfully organized imports")
     except ImportError:
-        logger.debug("isort library not available, import organization will be skipped")
+        logger.warning(
+            "isort library not available, import organization will be skipped. "
+            "Install with: pip install isort"
+        )
     except Exception as e:
         logger.warning(f"Failed to organize imports: {e}")
 
@@ -675,7 +678,10 @@ def format_python_code(code: str) -> str:
         logger.debug("Successfully formatted generated code")
         return formatted_code
     except ImportError:
-        logger.debug("black library not available, code formatting will be skipped")
+        logger.warning(
+            "black library not available, code formatting will be skipped. "
+            "Install with: pip install black"
+        )
         return code
     except black.InvalidInput as e:
         logger.warning(f"Failed to format generated code: {e}")


### PR DESCRIPTION
Summary:
When black or isort are not installed in the user's Python environment, the `format_python_code()` function silently skips formatting with only a DEBUG-level log. Users running `tritonparse reproduce` see no indication of why the generated reproducer code is unformatted.

Changed the log level from `logger.debug` to `logger.warning` and added actionable install instructions (e.g., "Install with: pip install black") so users immediately understand why formatting was skipped and how to fix it.

Reviewed By: bhuang7477

Differential Revision: D94126109


