### PR TITLE
Add verbose args print placeholder for reproducers

### DIFF
--- a/tritonparse/reproducer/function_extractor.py
+++ b/tritonparse/reproducer/function_extractor.py
@@ -259,6 +259,7 @@ def _generate_imports() -> str:
         "import io",
         "import json",
         "import logging",
+        "import os",
         "import sys",
         "from functools import lru_cache",
         "from pathlib import Path",

--- a/tritonparse/reproducer/templates/example.py
+++ b/tritonparse/reproducer/templates/example.py
@@ -29,10 +29,7 @@ logger = logging.getLogger(__name__)
 def launch_kernel():
     # {{LAUNCH_KERNEL_BODY_PLACEHOLDER}}
 
-    print("Generated kernel arguments dictionary:")
-    for name, arg in args_dict.items():  # noqa: F821
-        print(f"  {name}: {arg}")
-    print(f"Grid: {grid}")  # noqa: F821
+    # {{VERBOSE_ARGS_PRINT_PLACEHOLDER}}
 
     # {{KERNEL_INVOCATION_PLACEHOLDER}}
 

--- a/tritonparse/reproducer/templates/tritonbench.py
+++ b/tritonparse/reproducer/templates/tritonbench.py
@@ -43,15 +43,7 @@ KERNEL_NAME = "{{KERNEL_NAME_PLACEHOLDER}}"
 def _get_launch_kernel_args() -> Tuple[Tuple[int], Dict[str, Any]]:
     # {{LAUNCH_KERNEL_BODY_PLACEHOLDER}}
 
-    print("Recorded kernel arguments dictionary:")
-    for name, arg in args_dict.items():
-        if isinstance(arg, torch.Tensor):
-            print(
-                f"  {name}: Tensor:  {arg.shape} {arg.dtype} stride: {arg.stride()}, is_contiguous: {arg.is_contiguous()}"
-            )
-        else:
-            print(f"  {name}: {arg}")
-    print(f"Grid: {grid}")
+    # {{VERBOSE_ARGS_PRINT_PLACEHOLDER}}
 
     return tuple(grid), args_dict
 

--- a/tritonparse/reproducer/utils.py
+++ b/tritonparse/reproducer/utils.py
@@ -663,7 +663,10 @@ def format_python_code(code: str) -> str:
         )
         logger.debug("Successfully organized imports")
     except ImportError:
-        logger.debug("isort library not available, import organization will be skipped")
+        logger.warning(
+            "isort library not available, import organization will be skipped. "
+            "Install with: pip install isort"
+        )
     except Exception as e:
         logger.warning(f"Failed to organize imports: {e}")
 
@@ -675,7 +678,10 @@ def format_python_code(code: str) -> str:
         logger.debug("Successfully formatted generated code")
         return formatted_code
     except ImportError:
-        logger.debug("black library not available, code formatting will be skipped")
+        logger.warning(
+            "black library not available, code formatting will be skipped. "
+            "Install with: pip install black"
+        )
         return code
     except black.InvalidInput as e:
         logger.warning(f"Failed to format generated code: {e}")


### PR DESCRIPTION
Summary:
Previously, reproducer scripts always printed all kernel arguments and grid info unconditionally, which can be noisy for large kernels with many arguments.

This introduces a new `VERBOSE_ARGS_PRINT_PLACEHOLDER` in the template placeholder system. The generated code now gates verbose argument printing behind the `TRITONPARSE_REPRODUCE_VERBOSE=1` environment variable. Tensor arguments additionally print shape, dtype, stride, and is_contiguous info when verbose mode is enabled.

This follows the existing placeholder architecture (register placeholder → handler method → template substitution) rather than hardcoding print logic in templates.

Reviewed By: bhuang7477

Differential Revision: D94126108


