### PR TITLE
Fix OSS lint failures and gate Pages deploys (#425)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,15 +1,11 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger on push to main branch
-  push:
+  # Deploy after a successful push or manually dispatched validation on main.
+  workflow_run:
+    workflows: ["Website Build Test"]
+    types: [completed]
     branches: [main]
-    paths:
-      - "website/**"
-      - ".github/workflows/deploy-pages.yml"
-
-  # Allow manual trigger
-  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -25,6 +21,10 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'push' ||
+       github.event.workflow_run.event == 'workflow_dispatch')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -6,15 +6,21 @@ on:
     paths:
       - "website/**"
       - ".github/workflows/website-build.yml"
+      - ".github/workflows/deploy-pages.yml"
   pull_request:
     branches: [main]
     paths:
       - "website/**"
       - ".github/workflows/website-build.yml"
+      - ".github/workflows/deploy-pages.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: website-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-test:

--- a/tritonparse/parse/utils.py
+++ b/tritonparse/parse/utils.py
@@ -1,7 +1,6 @@
 #  Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import argparse
-import os
 import shutil
 from pathlib import Path
 from typing import Optional

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -233,13 +233,12 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
   }, [kernelsLeft, kernelsRight, leftIdx, rightIdx, leftLoadedFromLocal, leftKernelsFromLocal, leftLoadedUrlLocal, leftKernelsFromUrl]);
 
   // Resolve left/right kernels early for default panel computation
-  const leftArrayResolved = useMemo(() => (
+  const leftArrayResolved =
     (sess.left?.kernels?.length || 0) > 0
       ? sess.left.kernels
       : (leftLoadedFromLocal
         ? leftKernelsFromLocal
-        : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft))
-  ), [sess.left?.kernels, leftLoadedFromLocal, leftKernelsFromLocal, leftLoadedUrlLocal, leftKernelsFromUrl, kernelsLeft]);
+        : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft));
   const leftKernel = leftArrayResolved[leftIdx];
   const rightKernel = kernelsRight[rightIdx];
 

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -15,7 +15,7 @@ function safeExecTrim(command: string): string | null {
 }
 
 const packageJson = JSON.parse(
-  readFileSync(resolve(__dirname, 'package.json'), 'utf-8')
+  readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf-8')
 )
 
 // Build-time metadata


### PR DESCRIPTION
Summary:

Fix both lint failures surfaced by the latest OSS sync batch. Remove the stale `os` import and the unnecessary `useMemo` rejected by React Hooks lint.

Run GitHub Pages deployment only after a successful `Website Build Test` push or manual run on `main`, and check out the exact SHA that passed validation. Include deployment workflow changes in the website test path filters and cancel superseded website validation runs to prevent stale deployments.

Use `import.meta.dirname` in the Vite configuration so it is compatible with the upcoming native config loader default.

Reviewed By: wychi

Differential Revision: D118753908


