### PR TITLE
Isolate launch-hook tests from import state (#426)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,15 +1,11 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger on push to main branch
-  push:
+  # Deploy after a successful push or manually dispatched validation on main.
+  workflow_run:
+    workflows: ["Website Build Test"]
+    types: [completed]
     branches: [main]
-    paths:
-      - "website/**"
-      - ".github/workflows/deploy-pages.yml"
-
-  # Allow manual trigger
-  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -25,6 +21,10 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'push' ||
+       github.event.workflow_run.event == 'workflow_dispatch')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -6,15 +6,21 @@ on:
     paths:
       - "website/**"
       - ".github/workflows/website-build.yml"
+      - ".github/workflows/deploy-pages.yml"
   pull_request:
     branches: [main]
     paths:
       - "website/**"
       - ".github/workflows/website-build.yml"
+      - ".github/workflows/deploy-pages.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: website-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-test:

--- a/tests/cpu/test_inductor_hook_config.py
+++ b/tests/cpu/test_inductor_hook_config.py
@@ -76,6 +76,11 @@ class InductorHookConfigTest(unittest.TestCase):
                 "triton_trace_folder",
             )
         }
+        sl.TRITON_TRACE_LAUNCH = False
+        sl.TRITON_TRACE_LAUNCH_WITHIN_PROFILING = False
+        sl.TORCHINDUCTOR_RUN_JIT_POST_COMPILE_HOOK = False
+        sl.triton_trace_folder = None
+        sl._trace_launch_enabled = False
         self.trace_dir = tempfile.mkdtemp(prefix="tritonparse_inductor_hook_")
 
     def tearDown(self):

--- a/tests/cpu/test_multi_backend_stage.py
+++ b/tests/cpu/test_multi_backend_stage.py
@@ -670,5 +670,171 @@ class TestDeviceStringHelpers(unittest.TestCase):
         self.assertEqual(normalize_accelerator_device_string(""), "cpu")
 
 
+class TestAmdBufferOpsStatus(unittest.TestCase):
+    """Derived AMD buffer-ops enablement status in ir_analysis."""
+
+    _TTGIR = """\
+tt.func @kernel(%arg0: !tt.ptr<f32>) {
+  %0 = tt.load %arg0 : !tt.ptr<f32>
+  %1 = amdg.buffer_load %arg0 : !tt.ptr<f32>
+  %2 = amdg.buffer_load_to_local %arg0 : !tt.ptr<f32>
+  %3 = tt.atomic_rmw add, %arg0, %0 : !tt.ptr<f32>
+  %4 = amdg.buffer_atomic_rmw add, %arg0, %0 : !tt.ptr<f32>
+  tt.store %arg0, %1 : !tt.ptr<f32>
+}"""
+
+    _GCN_ALL_BUFFER = """\
+buffer_load_dwordx4 v[1:4], off, s[4:7], 0
+buffer_store_dwordx2 v[1:2], v3, s[4:5]
+"""
+
+    _GCN_PARTIAL = """\
+buffer_load_dwordx4 v[1:4], off, s[4:7], 0
+global_store_dwordx2 v[1:2], v3, s[4:5]
+"""
+
+    _GCN_NONE = """\
+global_load_dwordx4 v[1:4], off, s[4:7], 0
+global_store_dwordx2 v[1:2], v3, s[4:5]
+"""
+
+    _GCN_NO_MEMOPS = """\
+s_waitcnt vmcnt(0)
+v_add_u32 v1, v2, v3
+"""
+
+    _GCN_ALL_BUFFER_ATOMICS = """\
+buffer_atomic_add v1, off, s[4:7], v2
+buffer_atomic_cmpswap_x2 v[1:2], off, s[4:7], v[3:4]
+"""
+
+    _GCN_PARTIAL_ATOMIC = """\
+buffer_load_dwordx4 v[1:4], off, s[4:7], 0
+global_atomic_add v1, off, s[4:7], v2
+"""
+
+    _GCN_ONLY_GLOBAL_ATOMICS = """\
+global_atomic_add v1, off, s[4:7], v2
+global_atomic_cmpswap v1, off, s[4:7], v[2:3]
+flat_atomic_add v1, off, s[4:7], v2
+"""
+
+    def _entry(self, gcn: str):
+        return {
+            "payload": {
+                "metadata": {"backend_name": "hip"},
+                "file_content": {
+                    "kernel.ttgir": self._TTGIR,
+                    "kernel.amdgcn": gcn,
+                },
+                "file_path": {},
+                "source_mappings": {},
+            }
+        }
+
+    def _run_pass(self, gcn: str):
+        adapter = get_backend_registry().resolve(adapter_name="hip_triton")
+        return adapter.run_analysis_pass(
+            "amd_buffer_ops", self._entry(gcn), AnalyzerContext()
+        )
+
+    def test_all_buffer_enabled(self):
+        result = self._run_pass(self._GCN_ALL_BUFFER)
+        status = result["amd_buffer_ops"]
+        self.assertTrue(status["enabled"])
+        self.assertEqual(status["status"], "all_buffer")
+        self.assertEqual(status["buffer_load_count"], 1)
+        self.assertEqual(status["buffer_store_count"], 1)
+        self.assertEqual(status["global_load_count"], 0)
+        self.assertEqual(status["global_store_count"], 0)
+
+    def test_partial_not_enabled(self):
+        result = self._run_pass(self._GCN_PARTIAL)
+        status = result["amd_buffer_ops"]
+        self.assertFalse(status["enabled"])
+        self.assertEqual(status["status"], "partial")
+
+    def test_no_buffer_ops(self):
+        result = self._run_pass(self._GCN_NONE)
+        status = result["amd_buffer_ops"]
+        self.assertFalse(status["enabled"])
+        self.assertEqual(status["status"], "none")
+
+    def test_no_memops_unknown(self):
+        result = self._run_pass(self._GCN_NO_MEMOPS)
+        status = result["amd_buffer_ops"]
+        self.assertFalse(status["enabled"])
+        self.assertEqual(status["status"], "unknown")
+
+    def test_ttgir_prefix_and_atomics(self):
+        """Real amdg. prefix counted; load_to_local not double-counted."""
+        result = self._run_pass(self._GCN_ALL_BUFFER)
+        ttgir = result["io_counts"]["amd_ttgir_bufferops_count"]
+        self.assertEqual(ttgir["tt.load_count"], 1)
+        self.assertEqual(ttgir["tt.store_count"], 1)
+        self.assertEqual(ttgir["tt.atomic_rmw_count"], 1)
+        self.assertEqual(ttgir["tt.atomic_cas_count"], 0)
+        self.assertEqual(ttgir["amdg.buffer_load_count"], 1)
+        self.assertEqual(ttgir["amdg.buffer_load_to_local_count"], 1)
+        self.assertEqual(ttgir["amdg.buffer_store_count"], 0)
+        self.assertEqual(ttgir["amdg.buffer_atomic_rmw_count"], 1)
+        self.assertEqual(ttgir["amdg.buffer_atomic_cas_count"], 0)
+
+    def test_legacy_amdgpu_prefix_counted(self):
+        """Historical amdgpu. spelling still matches."""
+        from tritonparse.parse.ir_analysis import process_amd_ttgir_bufferops
+
+        counts = process_amd_ttgir_bufferops(
+            "k.ttgir",
+            {"k.ttgir": "%x = amdgpu.buffer_load %p : !tt.ptr<f32>"},
+            {},
+        )
+        self.assertEqual(counts["amdg.buffer_load_count"], 1)
+
+    def test_all_buffer_atomics_enabled(self):
+        result = self._run_pass(self._GCN_ALL_BUFFER_ATOMICS)
+        status = result["amd_buffer_ops"]
+        self.assertTrue(status["enabled"])
+        self.assertEqual(status["status"], "all_buffer")
+        self.assertEqual(status["buffer_atomic_count"], 2)
+
+    def test_partial_with_global_atomics(self):
+        result = self._run_pass(self._GCN_PARTIAL_ATOMIC)
+        status = result["amd_buffer_ops"]
+        self.assertFalse(status["enabled"])
+        self.assertEqual(status["status"], "partial")
+        self.assertEqual(status["global_atomic_count"], 1)
+
+    def test_only_global_atomics(self):
+        result = self._run_pass(self._GCN_ONLY_GLOBAL_ATOMICS)
+        status = result["amd_buffer_ops"]
+        self.assertFalse(status["enabled"])
+        self.assertEqual(status["status"], "none")
+        self.assertEqual(status["global_atomic_count"], 2)
+        self.assertEqual(status["flat_atomic_count"], 1)
+
+    def test_status_keeps_io_counts(self):
+        """The new field is additive: existing io_counts are unchanged."""
+        result = self._run_pass(self._GCN_ALL_BUFFER)
+        self.assertIn("io_counts", result)
+        self.assertIn("amd_buffer_ops", result)
+        self.assertEqual(
+            result["io_counts"]["amd_gcn_bufferops_count"]["buffer_load_count"], 1
+        )
+
+    def test_legacy_path_emits_status(self):
+        """Legacy fallback (unknown backend) emits amd_buffer_ops too."""
+        old = os.environ.pop("TRITONPARSE_ANALYSIS", None)
+        try:
+            entry = self._entry(self._GCN_ALL_BUFFER)
+            entry["payload"]["metadata"] = {"backend_name": "unknown"}
+            result = _generate_ir_analysis(entry, AnalyzerContext())
+        finally:
+            if old is not None:
+                os.environ["TRITONPARSE_ANALYSIS"] = old
+        self.assertIn("amd_buffer_ops", result)
+        self.assertTrue(result["amd_buffer_ops"]["enabled"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cpu/test_schema_validation.py
+++ b/tests/cpu/test_schema_validation.py
@@ -611,6 +611,39 @@ class ValidateRecordTest(unittest.TestCase):
         is_valid, errors = validate_record(record)
         self.assertTrue(is_valid, f"Unexpected errors: {errors}")
 
+    def test_ir_analysis_amd_buffer_ops_status(self):
+        """Derived AMD buffer-ops enablement status."""
+        record = {
+            "event_type": "ir_analysis",
+            "hash": "abc123",
+            "ir_analysis": {
+                "amd_buffer_ops": {
+                    "enabled": True,
+                    "status": "all_buffer",
+                    "buffer_load_count": 8,
+                    "buffer_store_count": 2,
+                    "buffer_atomic_count": 1,
+                    "global_load_count": 0,
+                    "global_store_count": 0,
+                    "global_atomic_count": 0,
+                    "flat_atomic_count": 0,
+                    "reason": "All 11 global memory op(s) in AMDGCN use buffer ops.",
+                }
+            },
+        }
+        is_valid, errors = validate_record(record)
+        self.assertTrue(is_valid, f"Unexpected errors: {errors}")
+
+    def test_ir_analysis_amd_buffer_ops_status_bad_enum(self):
+        """Invalid status enum values are rejected."""
+        record = {
+            "event_type": "ir_analysis",
+            "hash": "abc123",
+            "ir_analysis": {"amd_buffer_ops": {"enabled": True, "status": "sometimes"}},
+        }
+        is_valid, _ = validate_record(record)
+        self.assertFalse(is_valid)
+
     def test_ir_analysis_unknown_analysis_type_allowed(self):
         """Unknown analysis types pass (additionalProperties true on ir_analysis)."""
         record = {

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -17,9 +17,6 @@ import tritonparse.parse.utils
 import tritonparse.structured_logging
 
 log_path = "./logs"
-tritonparse.structured_logging.init(log_path, enable_trace_launch=True)
-
-os.environ["TORCHINDUCTOR_FX_GRAPH_CACHE"] = "0"
 
 
 @triton.jit
@@ -74,6 +71,8 @@ def test_tensor_add():
 
 
 if __name__ == "__main__":
+    tritonparse.structured_logging.init(log_path, enable_trace_launch=True)
+    os.environ["TORCHINDUCTOR_FX_GRAPH_CACHE"] = "0"
     test_tensor_add()
     # Use improved unified_parse with explicit output directory
     tritonparse.parse.utils.unified_parse(

--- a/tritonparse/parse/ir_analysis.py
+++ b/tritonparse/parse/ir_analysis.py
@@ -519,7 +519,7 @@ def _get_dtype_bits(dtype_str: str) -> int | None:
 # Achieved GB/s needs per-launch durations (absent from the trace) and stays a
 # profiler/NCU concern.
 
-# I/O ops counted in TTIR. amdgpu.buffer_* / global_* are TTGIR/AMDGCN-stage ops
+# I/O ops counted in TTIR. amdg.buffer_* / global_* are TTGIR/AMDGCN-stage ops
 # (covered by the amd_buffer_ops analyzer) and never appear in TTIR, so counting
 # only tt.load/tt.store here is both correct and avoids double counting.
 _ROOFLINE_IO_KEYS = ("tt.load", "tt.store")
@@ -853,20 +853,63 @@ def find_procedures_with_patterns(
     return results
 
 
-def process_amd_bufferop(ir_content: str, io_keys: list[str]) -> dict[str, int]:
-    def make_key(prefix: str) -> str:
-        return f"{prefix}_count"
+def process_amd_bufferop(
+    ir_content: str, io_keys: list[tuple[str, str]]
+) -> dict[str, int]:
+    """Count IR lines matching each (count_key, regex pattern) pair.
 
-    io_keys = [(make_key(prefix), prefix) for prefix in io_keys]
-    output: dict[str, int] = {}
-    for dict_key, _ in io_keys:
-        output[dict_key] = 0
+    Patterns are matched with ``re.search`` per line so word boundaries and
+    alternations can be expressed (e.g. the ``amdg.``/``amdgpu.`` dialect
+    prefix, or keeping ``buffer_load_to_local`` out of ``buffer_load``).
+    """
+    output: dict[str, int] = {key: 0 for key, _ in io_keys}
     if ir_content:
         for line in ir_content.split("\n"):
-            for dict_key, code_key in io_keys:
-                if code_key in line:
-                    output[dict_key] += 1
+            for key, pattern in io_keys:
+                if re.search(pattern, line):
+                    output[key] += 1
     return output
+
+
+# TTGIR op patterns. The AMDGPU dialect prints with the ``amdg.`` prefix
+# (``amdgpu`` is only the C++ namespace); both spellings are matched so
+# historical traces keep working. ``buffer_load`` excludes
+# ``buffer_load_to_local`` via a word boundary (``_`` is a word character,
+# so ``\\b`` never matches between ``load`` and ``_to_local``).
+_TTGIR_BUFFEROP_PATTERNS: list[tuple[str, str]] = [
+    ("tt.load_count", r"\btt\.load\b"),
+    ("tt.store_count", r"\btt\.store\b"),
+    ("tt.atomic_rmw_count", r"\btt\.atomic_rmw\b"),
+    ("tt.atomic_cas_count", r"\btt\.atomic_cas\b"),
+    ("amdg.buffer_load_count", r"\bamdg(?:pu)?\.buffer_load\b"),
+    (
+        "amdg.buffer_load_to_local_count",
+        r"\bamdg(?:pu)?\.buffer_load_to_local\b",
+    ),
+    ("amdg.buffer_store_count", r"\bamdg(?:pu)?\.buffer_store\b"),
+    (
+        "amdg.buffer_atomic_rmw_count",
+        r"\bamdg(?:pu)?\.buffer_atomic_rmw\b",
+    ),
+    (
+        "amdg.buffer_atomic_cas_count",
+        r"\bamdg(?:pu)?\.buffer_atomic_cas\b",
+    ),
+]
+
+# AMDGCN instruction patterns. Converted atomics disassemble as
+# ``buffer_atomic_*``; unconverted ones as ``global_atomic_*`` (global
+# address space). ``flat_atomic_*`` is not expected from Triton's lowering
+# but is counted separately so it can never silently pass as converted.
+_GCN_BUFFEROP_PATTERNS: list[tuple[str, str]] = [
+    ("global_load_count", "global_load"),
+    ("global_store_count", "global_store"),
+    ("buffer_load_count", "buffer_load"),
+    ("buffer_store_count", "buffer_store"),
+    ("buffer_atomic_count", "buffer_atomic"),
+    ("global_atomic_count", "global_atomic"),
+    ("flat_atomic_count", "flat_atomic"),
+]
 
 
 def process_amd_ttgir_bufferops(
@@ -875,9 +918,7 @@ def process_amd_ttgir_bufferops(
     file_path: dict[str, str],
 ) -> dict[str, int]:
     ir_content = load_ir_contents(key, file_content, file_path)
-    # TODO: Add atomics
-    io_keys = ["tt.load", "tt.store", "amdgpu.buffer_load", "amdgpu.buffer_store"]
-    return process_amd_bufferop(ir_content, io_keys)
+    return process_amd_bufferop(ir_content, _TTGIR_BUFFEROP_PATTERNS)
 
 
 def process_amd_gcn_bufferops(
@@ -886,9 +927,7 @@ def process_amd_gcn_bufferops(
     file_path: dict[str, str],
 ) -> dict[str, int]:
     ir_content = load_ir_contents(key, file_content, file_path)
-    # TODO: Add atomics
-    io_keys = ["global_load", "global_store", "buffer_load", "buffer_store"]
-    return process_amd_bufferop(ir_content, io_keys)
+    return process_amd_bufferop(ir_content, _GCN_BUFFEROP_PATTERNS)
 
 
 def find_loop_bounds(ir_content: str) -> list[tuple[int, int]]:
@@ -1236,6 +1275,89 @@ def _analyze_buffer_ops(
     return io_counts
 
 
+# Status values for the derived amd_buffer_ops field. AMDGCN is authoritative:
+# buffer ops are fully in effect only when no global_load/global_store remain
+# (the documented "check the GCN" verification).
+_BUFFER_OPS_ALL_BUFFER = "all_buffer"
+_BUFFER_OPS_PARTIAL = "partial"
+_BUFFER_OPS_NONE = "none"
+_BUFFER_OPS_UNKNOWN = "unknown"
+
+
+def _derive_amd_buffer_ops_status(
+    gcn_counts: dict[str, int],
+) -> dict[str, Any]:
+    """Derive whether AMD buffer ops are enabled from AMDGCN op counts.
+
+    Args:
+        gcn_counts: Count dict from ``process_amd_gcn_bufferops`` with
+            load/store counts plus ``buffer_atomic_count``,
+            ``global_atomic_count`` and ``flat_atomic_count`` keys.
+
+    Returns:
+        Status dict with ``enabled`` (True only when every global memory
+        op in AMDGCN is a buffer op, atomics included), ``status`` (one of
+        ``all_buffer``, ``partial``, ``none``, ``unknown``), the per-op
+        counts, and a human-readable ``reason``.
+    """
+    buffer_load = gcn_counts.get("buffer_load_count", 0)
+    buffer_store = gcn_counts.get("buffer_store_count", 0)
+    buffer_atomic = gcn_counts.get("buffer_atomic_count", 0)
+    global_load = gcn_counts.get("global_load_count", 0)
+    global_store = gcn_counts.get("global_store_count", 0)
+    global_atomic = gcn_counts.get("global_atomic_count", 0)
+    flat_atomic = gcn_counts.get("flat_atomic_count", 0)
+
+    buffer_total = buffer_load + buffer_store + buffer_atomic
+    non_buffer_atomic = global_atomic + flat_atomic
+    global_total = global_load + global_store + non_buffer_atomic
+
+    status_payload: dict[str, Any] = {
+        "enabled": False,
+        "status": _BUFFER_OPS_UNKNOWN,
+        "buffer_load_count": buffer_load,
+        "buffer_store_count": buffer_store,
+        "buffer_atomic_count": buffer_atomic,
+        "global_load_count": global_load,
+        "global_store_count": global_store,
+        "global_atomic_count": global_atomic,
+        "flat_atomic_count": flat_atomic,
+        "reason": "",
+    }
+
+    atomic_note = ""
+    if buffer_atomic or non_buffer_atomic:
+        atomic_note = (
+            f" Includes {buffer_atomic} buffer atomic(s) and "
+            f"{non_buffer_atomic} non-buffer atomic(s)."
+        )
+
+    if buffer_total + global_total == 0:
+        status_payload["reason"] = (
+            "No global memory ops found in AMDGCN; buffer-ops enablement is unknown."
+        )
+    elif global_total == 0:
+        status_payload["enabled"] = True
+        status_payload["status"] = _BUFFER_OPS_ALL_BUFFER
+        status_payload["reason"] = (
+            f"All {buffer_total} global memory op(s) in AMDGCN use buffer ops."
+            f"{atomic_note}"
+        )
+    elif buffer_total == 0:
+        status_payload["status"] = _BUFFER_OPS_NONE
+        status_payload["reason"] = (
+            f"No buffer ops in AMDGCN; {global_total} non-buffer global "
+            f"memory op(s) remain.{atomic_note}"
+        )
+    else:
+        status_payload["status"] = _BUFFER_OPS_PARTIAL
+        status_payload["reason"] = (
+            f"Partial conversion: {buffer_total} buffer op(s) but "
+            f"{global_total} non-buffer global memory op(s) remain.{atomic_note}"
+        )
+    return status_payload
+
+
 def _analyze_loop_schedules(
     ttir_key: str,
     ttgir_key: str,
@@ -1383,6 +1505,11 @@ def _generate_ir_analysis_legacy(
         io_counts = _analyze_buffer_ops(ttgir_key, amdgcn_key, file_content, file_path)
         if io_counts:
             ir_analysis["io_counts"] = io_counts
+            gcn_counts = io_counts.get("amd_gcn_bufferops_count")
+            if gcn_counts is not None:
+                ir_analysis["amd_buffer_ops"] = _derive_amd_buffer_ops_status(
+                    gcn_counts
+                )
     if (
         ttir_key
         and ttgir_key
@@ -1572,7 +1699,11 @@ def _analyze_amd_buffer_ops(
     io_counts = _analyze_buffer_ops(ttgir_key, amdgcn_key, file_content, file_path)
 
     if io_counts:
-        return {"io_counts": io_counts}
+        result: dict[str, Any] = {"io_counts": io_counts}
+        gcn_counts = io_counts.get("amd_gcn_bufferops_count")
+        if gcn_counts is not None:
+            result["amd_buffer_ops"] = _derive_amd_buffer_ops_status(gcn_counts)
+        return result
     return None
 
 

--- a/tritonparse/parse/utils.py
+++ b/tritonparse/parse/utils.py
@@ -1,7 +1,6 @@
 #  Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import argparse
-import os
 import shutil
 from pathlib import Path
 from typing import Optional

--- a/tritonparse/validation/schemas/ir_analysis.schema.json
+++ b/tritonparse/validation/schemas/ir_analysis.schema.json
@@ -18,11 +18,12 @@
     },
     "ir_analysis": {
       "type": "object",
-      "description": "Analysis results keyed by analysis type. Currently supports blockpingpong, io_counts, and loop_schedules.",
+      "description": "Analysis results keyed by analysis type. Currently supports blockpingpong, io_counts, amd_buffer_ops, and loop_schedules.",
       "additionalProperties": true,
       "properties": {
         "blockpingpong": { "$ref": "#/definitions/BlockPingpongResult" },
         "io_counts": { "$ref": "#/definitions/IOCounts" },
+        "amd_buffer_ops": { "$ref": "#/definitions/AmdBufferOpsStatus" },
         "loop_schedules": {
           "type": "array",
           "description": "Loop schedule analysis showing pipelined operation mapping to Python source lines.",
@@ -90,6 +91,54 @@
       "properties": {
         "amd_ttgir_bufferops_count": { "$ref": "#/definitions/BufferOpsCounts" },
         "amd_gcn_bufferops_count": { "$ref": "#/definitions/BufferOpsCounts" }
+      }
+    },
+    "AmdBufferOpsStatus": {
+      "type": "object",
+      "description": "Derived AMD buffer-ops enablement status. Grounded in AMDGCN: enabled is true only when every global memory op is a buffer op.",
+      "required": ["enabled", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "True only when all global memory ops in AMDGCN use buffer_load/buffer_store."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["all_buffer", "partial", "none", "unknown"],
+          "description": "Conversion outcome: all_buffer (fully converted), partial (mixed), none (no buffer ops), unknown (no global memory ops)."
+        },
+        "buffer_load_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "buffer_store_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "buffer_atomic_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "global_load_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "global_atomic_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "flat_atomic_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "global_store_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "reason": {
+          "type": "string"
+        }
       }
     },
     "LoopSchedule": {

--- a/website/src/pages/FileDiffView.tsx
+++ b/website/src/pages/FileDiffView.tsx
@@ -233,13 +233,12 @@ const FileDiffView: React.FC<FileDiffViewProps> = ({ kernelsLeft, selectedLeftIn
   }, [kernelsLeft, kernelsRight, leftIdx, rightIdx, leftLoadedFromLocal, leftKernelsFromLocal, leftLoadedUrlLocal, leftKernelsFromUrl]);
 
   // Resolve left/right kernels early for default panel computation
-  const leftArrayResolved = useMemo(() => (
+  const leftArrayResolved =
     (sess.left?.kernels?.length || 0) > 0
       ? sess.left.kernels
       : (leftLoadedFromLocal
         ? leftKernelsFromLocal
-        : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft))
-  ), [sess.left?.kernels, leftLoadedFromLocal, leftKernelsFromLocal, leftLoadedUrlLocal, leftKernelsFromUrl, kernelsLeft]);
+        : (leftLoadedUrlLocal ? leftKernelsFromUrl : kernelsLeft));
   const leftKernel = leftArrayResolved[leftIdx];
   const rightKernel = kernelsRight[rightIdx];
 

--- a/website/src/pages/IRAnalysis.tsx
+++ b/website/src/pages/IRAnalysis.tsx
@@ -40,11 +40,23 @@ const IRAnalysis: React.FC<IRAnalysisProps> = ({ kernels, selectedKernel }) => {
   }
 
   const io_counts = kernel.ir_analysis?.io_counts;
+  const buffer_ops = kernel.ir_analysis?.amd_buffer_ops;
   const ttgir_info = io_counts?.["amd_ttgir_bufferops_count"];
   const amdgcn_info = io_counts?.["amd_gcn_bufferops_count"];
   const loop_schedule = kernel.ir_analysis?.loop_schedules;
   const procedure_checks = kernel.ir_analysis?.procedure_checks;
-  const getCount = (info: Record<string, number> | undefined, key: string): string => { return info?.[key]?.toString() ?? "N/A"; };
+  const getCount = (
+    info: Record<string, number> | undefined,
+    ...keys: string[]
+  ): string => {
+    for (const key of keys) {
+      const count = info?.[key];
+      if (count !== undefined) {
+        return count.toString();
+      }
+    }
+    return "N/A";
+  };
 
   // Helper function to get procedure check status display
   const getProcedureCheckDisplay = (result: ProcedureCheckResult): { color: string; icon: string } => {
@@ -105,11 +117,29 @@ Check the specific conditions required for this procedure.`;
           Kernel: [{selectedKernel}] {kernel.name}
         </h2>
 
-        {io_counts && (ttgir_info || amdgcn_info) && (
+        {(buffer_ops || (io_counts && (ttgir_info || amdgcn_info))) && (
           <>
             <h3 className="text-lg font-medium mb-3 text-gray-800">
               AMD BufferOps Information
             </h3>
+
+            {buffer_ops && (
+              <div className="mb-4 flex items-center gap-2">
+                <span
+                  className={`inline-flex items-center px-2 py-1 rounded text-sm font-medium border ${
+                    buffer_ops.enabled
+                      ? "bg-green-100 text-green-800 border-green-200"
+                      : "bg-red-100 text-red-800 border-red-200"
+                  }`}
+                >
+                  {buffer_ops.enabled ? "✓" : "✗"} Buffer Ops{" "}
+                  {buffer_ops.enabled ? "Enabled" : "Not Fully Enabled"} ({buffer_ops.status})
+                </span>
+                {buffer_ops.reason && (
+                  <span className="text-sm text-gray-600">{buffer_ops.reason}</span>
+                )}
+              </div>
+            )}
 
             <div className="bg-gray-50 p-4 rounded-md border border-gray-200 mb-6">
               <div className="grid grid-cols-[repeat(auto-fit,_minmax(180px,_1fr))] gap-3">
@@ -125,11 +155,31 @@ Check the specific conditions required for this procedure.`;
                     </div>
                     <div className="flex flex-col">
                       <span className="text-sm font-medium text-gray-500">Tiled Buffer Load Count</span>
-                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "amdgpu.buffer_load_count")}</span>
+                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "amdg.buffer_load_count", "amdgpu.buffer_load_count")}</span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-gray-500">Tiled Buffer Load-To-Local Count</span>
+                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "amdg.buffer_load_to_local_count")}</span>
                     </div>
                     <div className="flex flex-col">
                       <span className="text-sm font-medium text-gray-500">Tiled Buffer Store Count</span>
-                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "amdgpu.buffer_store_count")}</span>
+                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "amdg.buffer_store_count", "amdgpu.buffer_store_count")}</span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-gray-500">Tiled Atomic RMW Count</span>
+                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "tt.atomic_rmw_count")}</span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-gray-500">Tiled Atomic CAS Count</span>
+                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "tt.atomic_cas_count")}</span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-gray-500">Tiled Buffer Atomic RMW Count</span>
+                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "amdg.buffer_atomic_rmw_count")}</span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-gray-500">Tiled Buffer Atomic CAS Count</span>
+                      <span className="font-mono text-sm break-words">{getCount(ttgir_info, "amdg.buffer_atomic_cas_count")}</span>
                     </div>
                   </>
                 )}
@@ -150,6 +200,18 @@ Check the specific conditions required for this procedure.`;
                     <div className="flex flex-col">
                       <span className="text-sm font-medium text-gray-500">AMDGCN Buffer Store Instruction Count</span>
                       <span className="font-mono text-sm break-words">{getCount(amdgcn_info, "buffer_store_count")}</span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-gray-500">AMDGCN Buffer Atomic Instruction Count</span>
+                      <span className="font-mono text-sm break-words">{getCount(amdgcn_info, "buffer_atomic_count")}</span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-gray-500">AMDGCN Global Atomic Instruction Count</span>
+                      <span className="font-mono text-sm break-words">{getCount(amdgcn_info, "global_atomic_count")}</span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-gray-500">AMDGCN Flat Atomic Instruction Count</span>
+                      <span className="font-mono text-sm break-words">{getCount(amdgcn_info, "flat_atomic_count")}</span>
                     </div>
                   </>
                 )}

--- a/website/src/utils/dataLoader.ts
+++ b/website/src/utils/dataLoader.ts
@@ -228,9 +228,24 @@ export interface DisplayAttribute {
     compute_from?: string[];
 }
 
+export interface AmdBufferOpsStatus {
+    enabled: boolean;
+    status: 'all_buffer' | 'partial' | 'none' | 'unknown';
+    buffer_load_count?: number;
+    buffer_store_count?: number;
+    buffer_atomic_count?: number;
+    global_load_count?: number;
+    global_store_count?: number;
+    global_atomic_count?: number;
+    flat_atomic_count?: number;
+    reason?: string;
+}
+
 export interface IRAnalysisData {
     // Mapping from IR stage -> <IO type -> count>
     io_counts?: Record<string, Record<string, number>>;
+    // Derived AMD buffer-ops enablement status (grounded in AMDGCN counts)
+    amd_buffer_ops?: AmdBufferOpsStatus;
     loop_schedules?: [Record<string, [string]>];
     // FileCheck-based procedure detection results
     procedure_checks?: Record<string, ProcedureCheckResult>;

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -15,7 +15,7 @@ function safeExecTrim(command: string): string | null {
 }
 
 const packageJson = JSON.parse(
-  readFileSync(resolve(__dirname, 'package.json'), 'utf-8')
+  readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf-8')
 )
 
 // Build-time metadata


### PR DESCRIPTION
Summary:

OSS `unittest discover` imports every `test*.py` module before running suites. `tests/test_add.py` enabled launch tracing at import time, leaving `TRITON_TRACE_LAUNCH` set and causing `test_init_without_launch_leaves_inductor_alone` to fail in both pip and nightly jobs.

Move script-only initialization under `__main__`, and make the Inductor hook test establish a clean launch-tracing baseline while preserving and restoring caller state.

Reviewed By: wychi

Differential Revision: D118825089


