### PR TITLE
CI: fail loudly when Triton-nightly pin resolution fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -354,6 +354,7 @@ jobs:
                       -e HIP_VISIBLE_DEVICES -e CUDA_VISIBLE_DEVICES \
                       -e TORCHINDUCTOR_COMPILE_THREADS -e TORCHINDUCTOR_MAX_AUTOTUNE \
                       -e TEST_TYPE -e COVERAGE \
+                      -e GITHUB_TOKEN=${{ github.token }} \
                       -v "$GITHUB_WORKSPACE:/tmp/workspace" \
                       -w /tmp/workspace \
                       "${ROCM_IMAGE}" bash -c '
@@ -374,6 +375,28 @@ jobs:
                           # (seen 2026-09-07: every zstandard import
                           # failed with 77 unittest errors).
                           python -m pip --version >/dev/null 2>&1 || python -m ensurepip --upgrade
+                          # Replace the image's triton (3.8.0) with
+                          # upstream nightly HEAD via the shared
+                          # resolver — same pin logic as the CUDA job.
+                          # The image's triton predates the MI350 LLVM
+                          # segfault fix (triton-lang/triton#10523):
+                          # compiling any autotuned kernel on gfx950
+                          # segfaults (exit 139, seen 2026-09-07). The
+                          # image keeps providing the torch-ROCm stack;
+                          # only the compiler is swapped.
+                          python -m pip uninstall -y pytorch-triton triton 2>/dev/null || true
+                          PY_TAG=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
+                          PIN=$(python /tmp/workspace/.ci/triton_nightly_pin.py --pytag "$PY_TAG" --platform x86_64) || PIN=""
+                          if [[ "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
+                              echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
+                              python -m pip install "triton==$PIN" \
+                                  --extra-index-url "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
+                          else
+                              echo "Resolver did not produce a valid pin (got: '$PIN'); falling back to default"
+                              python -m pip install -U --pre triton \
+                                  --extra-index-url "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
+                          fi
+                          python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
                           python -m pip install -e "/tmp/workspace/.[test]"
                           if [[ "${COVERAGE}" == "true" ]]; then
                               RUNNER="coverage run -m unittest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,164 +269,112 @@ jobs:
     # ===================================================================
     # GPU tests on AMD MI350 (gfx950) self-hosted runner, ROCm nightly.
     #
-    # Architecture: host-direct (NO `container:`). Unlike the NVIDIA
-    # jobs, we do not run inside a container image: ROCm needs
-    # /dev/kfd + /dev/dri device passthrough, and the runner host
-    # already ships a working ROCm stack + driver. This mirrors how
-    # pytorch/pytorch runs its own MI350 CI
-    # (rocm-mi350.yml -> linux.rocm.gpu.gfx950.1, docker-less test
-    # path via _rocm-test.yml).
+    # Architecture: prebuilt ROCm docker image + explicit `docker run`
+    # with GPU device passthrough. This copies tritonbench's
+    # `_linux-test-mi350.yml`, which runs on this exact same
+    # `amd-mi350-runner` pool. (An earlier revision of this job tried
+    # host-direct pip installs, but the runner host has no conda and
+    # wheel-based torch-ROCm setup is exactly what the tritonbench
+    # image already bakes in — see dispatch runs 34144336441 and
+    # 34145668510.)
+    #
+    # Image: `ghcr.io/meta-pytorch/tritonbench:rocm-latest`, built
+    # nightly from `rocm/pytorch:latest` + torch-ROCm + triton-main
+    # (see tritonbench `docker-rocm.yaml`). Verified 2026-09-07: the
+    # package is publicly pullable and its PYTORCH_ROCM_ARCH covers
+    # gfx950. The image's triton-main already contains the MI350 LLVM
+    # segfault fix (triton-lang/triton#10523). Pin to a dated
+    # `rocm-devYYYYMMDD` tag (same repo, pushed by docker-rocm.yaml)
+    # once this job is green — `rocm-latest` floats daily.
     #
     # Runner: `amd-mi350-runner` is the repo-visible ARC scale set
     # (ephemeral, 1 job per VM — same isolation semantics as the
     # g5.4xlarge NVIDIA runners). Fallback, if the scale set is ever
     # drained, is the shared PyTorch ROCm pool 1-GPU slice:
-    # `linux.rocm.gpu.meta-pytorch.mi350.1` (run-tests.sh only ever
-    # uses a single GPU). gfx942 (MI300X) slices are intentionally
-    # left out until this job is green.
+    # `linux.rocm.gpu.meta-pytorch.mi350.1`. gfx942 (MI300X) slices
+    # are intentionally left out until this job is green.
     #
     # Gating: `workflow_dispatch`-only while stabilizing. The GPU
     # self-hosted pool already queues for hours (see the 2.5h queue
     # on the 2026-09-04 main push); do NOT attach this to
     # pull_request until it is green several dispatches in a row.
-    #
-    # Known first-run unknown: PYTORCH_ROCM_TAG must match the
-    # runner's ROCm major version. `rocm7.1` is verified to exist as
-    # a nightly channel (see https://download.pytorch.org/whl/nightly/
-    # index, probed 2026-09-07). The Probe step below prints the
-    # host's actual ROCm version — if pip refuses the wheel set,
-    # adjust the tag to match and re-dispatch.
     # ===================================================================
     test-rocm-nightly:
         if: github.event_name == 'workflow_dispatch'
         runs-on: amd-mi350-runner
-        timeout-minutes: 90
+        timeout-minutes: 120
         env:
-            CONDA_ENV: tritonparse-rocm
-            PYTHON_VERSION: "3.14"
-            PYTORCH_ROCM_TAG: rocm7.1
-            # Same NVIDIA-published Triton nightly feed as the CUDA
-            # job: upstream Triton wheels bundle the AMD backend, so
-            # the pin + replace logic below is shared unchanged.
-            TRITON_NIGHTLY_INDEX_URL: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
-            # HIP honors HIP_VISIBLE_DEVICES; keep CUDA_VISIBLE_DEVICES
-            # alongside it since run-tests.sh exports the latter and
-            # recent ROCm stacks respect both.
+            ROCM_IMAGE: ghcr.io/meta-pytorch/tritonbench:rocm-latest
+            TEST_TYPE: ${{ github.event.inputs.test-type || 'all' }}
+            COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
+            # Single-GPU slice, same as run-tests.sh's
+            # CUDA_VISIBLE_DEVICES=0 on the NVIDIA jobs. HIP honors
+            # HIP_VISIBLE_DEVICES; keep both set.
             HIP_VISIBLE_DEVICES: "0"
             CUDA_VISIBLE_DEVICES: "0"
+            # Same inductor workarounds as tritonbench's test-gpu.sh:
+            # avoids "Could not find an active GPU backend" in
+            # subprocess workers and speeds up runs.
+            TORCHINDUCTOR_COMPILE_THREADS: "1"
+            TORCHINDUCTOR_MAX_AUTOTUNE: "0"
         steps:
             - uses: actions/checkout@v6
 
             - name: Probe ROCm host
               run: |
                   whoami
-                  python3 --version || true
-                  command -v conda || ls /opt/conda/bin/conda /opt/miniconda3/bin/conda "$HOME/miniconda3/bin/conda" 2>/dev/null || true
+                  docker --version
                   rocm-smi 2>/dev/null || true
-                  cat /opt/rocm/.info/version 2>/dev/null || true
                   rocminfo 2>/dev/null | grep -m4 -E "Marketing Name|gfx" || true
 
-            - name: Install Miniconda (if missing)
-              # The runner host has system Python but no conda (probed
-              # 2026-09-07). Install to $HOME (no sudo needed) and
-              # export CONDA_HOME for the setup step below. Same
-              # installer approach as .ci/setup.sh, user-local path.
+            - name: Pull ROCm test image
               run: |
-                  if command -v conda >/dev/null 2>&1 || [[ -x /opt/conda/bin/conda || -x /opt/miniconda3/bin/conda ]]; then
-                      echo "conda already present, skipping install"
-                      exit 0
+                  # Public package: anonymous pull works, but authenticate
+                  # to avoid rate limits (best-effort, non-fatal).
+                  echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin || true
+                  docker pull "${ROCM_IMAGE}"
+                  # Record the exact digest in the log so any green run
+                  # is reproducible even though the tag floats.
+                  docker inspect --format='image digest: {{index .RepoDigests 0}}' "${ROCM_IMAGE}"
+
+            - name: Run tests in ROCm container
+              run: |
+                  # GPU passthrough flags copied from tritonbench's
+                  # _linux-test-mi350.yml (same runner pool). The
+                  # gha-gpu-isolation-settings env file exists on these
+                  # hosts; skip it gracefully if ever absent.
+                  GPU_FLAGS="--device /dev/kfd --device /dev/dri --security-opt seccomp=unconfined --group-add video"
+                  ENV_FILE=""
+                  if [[ -f /etc/podinfo/gha-gpu-isolation-settings ]]; then
+                      ENV_FILE="--env-file /etc/podinfo/gha-gpu-isolation-settings"
                   fi
-                  echo "Installing Miniconda to $HOME/miniconda3 ..."
-                  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/Miniconda3-latest-Linux-x86_64.sh
-                  bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -u -p "$HOME/miniconda3"
-                  echo "CONDA_HOME=$HOME/miniconda3" >> "$GITHUB_ENV"
-                  echo "Installed: $("$HOME/miniconda3/bin/conda" --version)"
-
-            - name: Mark workspace as safe for git
-              # Same rationale as the NVIDIA jobs: setuptools-scm needs
-              # git introspection during 'pip install -e .'.
-              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-            - name: Get daily cache timestamp
-              id: daily-cache
-              run: |
-                  DATE_STAMP=$(date +"%Y-%m-%d")
-                  echo "date=$DATE_STAMP" >> $GITHUB_OUTPUT
-                  echo "Using daily cache stamp: $DATE_STAMP"
-
-            - name: Cache pip dependencies
-              uses: actions/cache@v5
-              with:
-                  # Host-direct run (no container), so pip's cache is
-                  # under the runner user's real HOME — NOT
-                  # /github/home as in the container jobs.
-                  path: ~/.cache/pip
-                  key: ${{ runner.os }}-pip-${{ env.PYTORCH_ROCM_TAG }}-py${{ env.PYTHON_VERSION }}-${{ steps.daily-cache.outputs.date }}
-                  restore-keys: |
-                      ${{ runner.os }}-pip-${{ env.PYTORCH_ROCM_TAG }}-py${{ env.PYTHON_VERSION }}-
-
-            - name: Setup conda env + PyTorch ROCm nightly + Triton nightly
-              env:
-                  # Same as the CUDA job: lets the Triton-nightly
-                  # resolver below authenticate to the GitHub API.
-                  GITHUB_TOKEN: ${{ github.token }}
-              run: |
-                  # Locate conda: PATH first, then CONDA_HOME (set by the
-                  # Miniconda step when it had to install), then the
-                  # well-known prefixes. Fail fast with a clear message
-                  # (the Probe step above shows what the host has).
-                  CONDA_BIN="$(command -v conda 2>/dev/null || true)"
-                  for candidate in "${CONDA_HOME:-}/bin/conda" /opt/conda/bin/conda /opt/miniconda3/bin/conda "$HOME/miniconda3/bin/conda"; do
-                      if [[ -z "$CONDA_BIN" && -x "$candidate" ]]; then
-                          CONDA_BIN="$candidate"
-                      fi
-                  done
-                  if [[ -z "$CONDA_BIN" ]]; then
-                      echo "ERROR: conda not found (PATH, CONDA_HOME, /opt/conda, /opt/miniconda3, ~/miniconda3)."
-                      echo "See the 'Probe ROCm host' step output and either provision conda or extend this search."
-                      exit 1
-                  fi
-                  echo "Using conda: $CONDA_BIN"
-                  eval "$("$CONDA_BIN" shell.bash hook)"
-                  # NOTE: explicitly request `pip`: conda-forge's
-                  # `python` package does NOT pull pip in by default
-                  # (same caveat as .ci/setup.sh).
-                  conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" pip -y -c conda-forge
-                  conda activate "$CONDA_ENV"
-
-                  # PyTorch nightly for ROCm. These are wheel-based
-                  # installs (bundled ROCm user-space libs); only the
-                  # kernel driver comes from the host, so the tag must
-                  # match the host ROCm major version (see job header).
-                  pip install --pre torch torchvision torchaudio \
-                      --index-url "https://download.pytorch.org/whl/nightly/${PYTORCH_ROCM_TAG}"
-                  pip install packaging
-                  python -c "import torch; print(f'torch: {torch.__version__}'); print(f'cuda available (HIP backend): {torch.cuda.is_available()}')"
-
-                  # Replace the pytorch-triton snapshot with the upstream
-                  # Triton nightly (bundles the AMD backend), pinning to
-                  # upstream HEAD via the same resolver as the CUDA job.
-                  pip uninstall -y pytorch-triton triton 2>/dev/null || true
-                  PY_TAG=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
-                  PIN=$(python .ci/triton_nightly_pin.py --pytag "$PY_TAG" --platform x86_64) || PIN=""
-                  if [[ "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
-                      echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
-                      pip install "triton==$PIN" \
-                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
-                  else
-                      echo "Resolver did not produce a valid pin (got: '$PIN'); falling back to default"
-                      pip install -U --pre triton \
-                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
-                  fi
-                  python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
-
-            - name: Install project dependencies
-              run: |
-                  bash .ci/install-project.sh
-
-            - name: Run tests
-              env:
-                  TEST_TYPE: ${{ github.event.inputs.test-type || 'all' }}
-                  COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
-              run: |
-                  bash .ci/run-tests.sh
+                  docker run --rm \
+                      $GPU_FLAGS $ENV_FILE \
+                      --ipc=host --shm-size=8g \
+                      -e HIP_VISIBLE_DEVICES -e CUDA_VISIBLE_DEVICES \
+                      -e TORCHINDUCTOR_COMPILE_THREADS -e TORCHINDUCTOR_MAX_AUTOTUNE \
+                      -e TEST_TYPE -e COVERAGE \
+                      -v "$GITHUB_WORKSPACE:/tmp/workspace" \
+                      -w /tmp/workspace \
+                      "${ROCM_IMAGE}" bash -c '
+                          set -e
+                          source /workspace/setup_instance.sh
+                          python -c "import torch, triton; print(f\"torch: {torch.__version__}\"); print(f\"triton: {triton.__version__} from {triton.__file__}\"); print(f\"cuda available (HIP backend): {torch.cuda.is_available()}\")"
+                          # Container runs as root while the checkout is
+                          # owned by the host `runner` user: same
+                          # dubious-ownership story as the NVIDIA jobs,
+                          # fixed the same way (setuptools-scm needs git
+                          # introspection for `pip install -e .`).
+                          git config --global --add safe.directory /tmp/workspace
+                          pip install -e "/tmp/workspace/.[test]"
+                          if [[ "${COVERAGE}" == "true" ]]; then
+                              RUNNER="coverage run -m unittest"
+                          else
+                              RUNNER="python -m unittest"
+                          fi
+                          case "${TEST_TYPE}" in
+                              cpu) $RUNNER discover -s tests/cpu -t . -v ;;
+                              cuda|gpu) $RUNNER discover -s tests/gpu -t . -v ;;
+                              *) $RUNNER discover -s tests -t . -v ;;
+                          esac
+                      '

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -321,9 +321,26 @@ jobs:
               run: |
                   whoami
                   python3 --version || true
-                  command -v conda || ls /opt/conda/bin/conda /opt/miniconda3/bin/conda 2>/dev/null || true
-                  rocm-smi --showid 2>/dev/null || rocm-smi 2>/dev/null || true
+                  command -v conda || ls /opt/conda/bin/conda /opt/miniconda3/bin/conda "$HOME/miniconda3/bin/conda" 2>/dev/null || true
+                  rocm-smi 2>/dev/null || true
+                  cat /opt/rocm/.info/version 2>/dev/null || true
                   rocminfo 2>/dev/null | grep -m4 -E "Marketing Name|gfx" || true
+
+            - name: Install Miniconda (if missing)
+              # The runner host has system Python but no conda (probed
+              # 2026-09-07). Install to $HOME (no sudo needed) and
+              # export CONDA_HOME for the setup step below. Same
+              # installer approach as .ci/setup.sh, user-local path.
+              run: |
+                  if command -v conda >/dev/null 2>&1 || [[ -x /opt/conda/bin/conda || -x /opt/miniconda3/bin/conda ]]; then
+                      echo "conda already present, skipping install"
+                      exit 0
+                  fi
+                  echo "Installing Miniconda to $HOME/miniconda3 ..."
+                  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/Miniconda3-latest-Linux-x86_64.sh
+                  bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -u -p "$HOME/miniconda3"
+                  echo "CONDA_HOME=$HOME/miniconda3" >> "$GITHUB_ENV"
+                  echo "Installed: $("$HOME/miniconda3/bin/conda" --version)"
 
             - name: Mark workspace as safe for git
               # Same rationale as the NVIDIA jobs: setuptools-scm needs
@@ -354,23 +371,27 @@ jobs:
                   # resolver below authenticate to the GitHub API.
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
-                  # Locate conda: PATH first, then the well-known
-                  # prefixes. Fail fast with a clear message (the
-                  # Probe step above shows what the host has).
+                  # Locate conda: PATH first, then CONDA_HOME (set by the
+                  # Miniconda step when it had to install), then the
+                  # well-known prefixes. Fail fast with a clear message
+                  # (the Probe step above shows what the host has).
                   CONDA_BIN="$(command -v conda 2>/dev/null || true)"
-                  for candidate in /opt/conda/bin/conda /opt/miniconda3/bin/conda; do
+                  for candidate in "${CONDA_HOME:-}/bin/conda" /opt/conda/bin/conda /opt/miniconda3/bin/conda "$HOME/miniconda3/bin/conda"; do
                       if [[ -z "$CONDA_BIN" && -x "$candidate" ]]; then
                           CONDA_BIN="$candidate"
                       fi
                   done
                   if [[ -z "$CONDA_BIN" ]]; then
-                      echo "ERROR: conda not found on PATH or in /opt/conda, /opt/miniconda3."
+                      echo "ERROR: conda not found (PATH, CONDA_HOME, /opt/conda, /opt/miniconda3, ~/miniconda3)."
                       echo "See the 'Probe ROCm host' step output and either provision conda or extend this search."
                       exit 1
                   fi
                   echo "Using conda: $CONDA_BIN"
                   eval "$("$CONDA_BIN" shell.bash hook)"
-                  conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
+                  # NOTE: explicitly request `pip`: conda-forge's
+                  # `python` package does NOT pull pip in by default
+                  # (same caveat as .ci/setup.sh).
+                  conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" pip -y -c conda-forge
                   conda activate "$CONDA_ENV"
 
                   # PyTorch nightly for ROCm. These are wheel-based

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,20 +180,18 @@ jobs:
                   # doesn't matter because the script is stdlib-only and
                   # PY_TAG is derived from that same interpreter, so the
                   # platform tag we filter on always matches the install
-                  # target. On any resolver failure, fall back to the
-                  # unpinned install (preserves the original behavior so
-                  # this leg never regresses).
+                  # target. On resolver failure, fail loudly instead of
+                  # silently testing a stale Triton (fail-loud policy).
                   PY_TAG=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
                   PIN=$(python .ci/triton_nightly_pin.py --pytag "$PY_TAG" --platform x86_64) || PIN=""
-                  if [[ "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
-                      echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
-                      pip install "triton==$PIN" \
-                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
-                  else
-                      echo "Resolver did not produce a valid pin (got: '$PIN'); falling back to default"
-                      pip install -U --pre triton \
-                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
+                  if [[ ! "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
+                      echo "ERROR: Triton-nightly resolver produced no valid pin (got: '$PIN')."
+                      echo "Failing instead of testing a stale Triton: re-dispatch once the feed catches up."
+                      exit 1
                   fi
+                  echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
+                  pip install "triton==$PIN" \
+                      --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
                   python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
 
             - name: Install project dependencies
@@ -404,18 +402,19 @@ jobs:
                   # Replace the pytorch-triton snapshot with the upstream
                   # Triton nightly (bundles the AMD backend), pinning to
                   # upstream HEAD via the same resolver as the CUDA job.
+                  # Fail-loud policy (same as CUDA job): never silently
+                  # test a stale Triton.
                   pip uninstall -y pytorch-triton triton 2>/dev/null || true
                   PY_TAG=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
                   PIN=$(python .ci/triton_nightly_pin.py --pytag "$PY_TAG" --platform x86_64) || PIN=""
-                  if [[ "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
-                      echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
-                      pip install "triton==$PIN" \
-                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
-                  else
-                      echo "Resolver did not produce a valid pin (got: '$PIN'); falling back to default"
-                      pip install -U --pre triton \
-                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
+                  if [[ ! "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
+                      echo "ERROR: Triton-nightly resolver produced no valid pin (got: '$PIN')."
+                      echo "Failing instead of testing a stale Triton: re-dispatch once the feed catches up."
+                      exit 1
                   fi
+                  echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
+                  pip install "triton==$PIN" \
+                      --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
                   python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
 
             - name: Install project dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,20 +285,18 @@ jobs:
     # uses a single GPU). gfx942 (MI300X) slices are intentionally
     # left out until this job is green.
     #
-    # Gating: `workflow_dispatch`-only while stabilizing. The GPU
-    # self-hosted pool already queues for hours (see the 2.5h queue
-    # on the 2026-09-04 main push); do NOT attach this to
-    # pull_request until it is green several dispatches in a row.
+    # Gating: runs on pull_request / push like the NVIDIA jobs (green
+    # on dispatches 34145668510 and 34157688605). `workflow_dispatch`
+    # stays available for manual re-runs. Note the GPU self-hosted
+    # pool can queue for hours (see the 2.5h queue on the 2026-09-04
+    # main push).
     #
-    # Known first-run unknown: PYTORCH_ROCM_TAG must match the
-    # runner's ROCm major version. `rocm7.1` is verified to exist as
-    # a nightly channel (see https://download.pytorch.org/whl/nightly/
-    # index, probed 2026-09-07). The Probe step below prints the
-    # host's actual ROCm version — if pip refuses the wheel set,
-    # adjust the tag to match and re-dispatch.
+    # PYTORCH_ROCM_TAG must match the runner's ROCm major version.
+    # `rocm7.1` is verified working on the current hosts (dispatch
+    # 34145668510); the Probe step prints the host stack for
+    # re-validation if runners are reprovisioned.
     # ===================================================================
     test-rocm-nightly:
-        if: github.event_name == 'workflow_dispatch'
         runs-on: amd-mi350-runner
         timeout-minutes: 90
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,143 +269,164 @@ jobs:
     # ===================================================================
     # GPU tests on AMD MI350 (gfx950) self-hosted runner, ROCm nightly.
     #
-    # Architecture: prebuilt ROCm docker image + explicit `docker run`
-    # with GPU device passthrough. This copies tritonbench's
-    # `_linux-test-mi350.yml`, which runs on this exact same
-    # `amd-mi350-runner` pool. (An earlier revision of this job tried
-    # host-direct pip installs, but the runner host has no conda and
-    # wheel-based torch-ROCm setup is exactly what the tritonbench
-    # image already bakes in — see dispatch runs 34144336441 and
-    # 34145668510.)
-    #
-    # Image: `ghcr.io/meta-pytorch/tritonbench:rocm-latest`, built
-    # nightly from `rocm/pytorch:latest` + torch-ROCm + triton-main
-    # (see tritonbench `docker-rocm.yaml`). Verified 2026-09-07: the
-    # package is publicly pullable and its PYTORCH_ROCM_ARCH covers
-    # gfx950. The image's triton-main already contains the MI350 LLVM
-    # segfault fix (triton-lang/triton#10523). Pin to a dated
-    # `rocm-devYYYYMMDD` tag (same repo, pushed by docker-rocm.yaml)
-    # once this job is green — `rocm-latest` floats daily.
+    # Architecture: host-direct (NO `container:`). Unlike the NVIDIA
+    # jobs, we do not run inside a container image: ROCm needs
+    # /dev/kfd + /dev/dri device passthrough, and the runner host
+    # already ships a working ROCm stack + driver. This mirrors how
+    # pytorch/pytorch runs its own MI350 CI
+    # (rocm-mi350.yml -> linux.rocm.gpu.gfx950.1, docker-less test
+    # path via _rocm-test.yml).
     #
     # Runner: `amd-mi350-runner` is the repo-visible ARC scale set
     # (ephemeral, 1 job per VM — same isolation semantics as the
     # g5.4xlarge NVIDIA runners). Fallback, if the scale set is ever
     # drained, is the shared PyTorch ROCm pool 1-GPU slice:
-    # `linux.rocm.gpu.meta-pytorch.mi350.1`. gfx942 (MI300X) slices
-    # are intentionally left out until this job is green.
+    # `linux.rocm.gpu.meta-pytorch.mi350.1` (run-tests.sh only ever
+    # uses a single GPU). gfx942 (MI300X) slices are intentionally
+    # left out until this job is green.
     #
     # Gating: `workflow_dispatch`-only while stabilizing. The GPU
     # self-hosted pool already queues for hours (see the 2.5h queue
     # on the 2026-09-04 main push); do NOT attach this to
     # pull_request until it is green several dispatches in a row.
+    #
+    # Known first-run unknown: PYTORCH_ROCM_TAG must match the
+    # runner's ROCm major version. `rocm7.1` is verified to exist as
+    # a nightly channel (see https://download.pytorch.org/whl/nightly/
+    # index, probed 2026-09-07). The Probe step below prints the
+    # host's actual ROCm version — if pip refuses the wheel set,
+    # adjust the tag to match and re-dispatch.
     # ===================================================================
     test-rocm-nightly:
         if: github.event_name == 'workflow_dispatch'
         runs-on: amd-mi350-runner
-        timeout-minutes: 120
+        timeout-minutes: 90
         env:
-            ROCM_IMAGE: ghcr.io/meta-pytorch/tritonbench:rocm-latest
-            TEST_TYPE: ${{ github.event.inputs.test-type || 'all' }}
-            COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
-            # Single-GPU slice, same as run-tests.sh's
-            # CUDA_VISIBLE_DEVICES=0 on the NVIDIA jobs. HIP honors
-            # HIP_VISIBLE_DEVICES; keep both set.
+            CONDA_ENV: tritonparse-rocm
+            PYTHON_VERSION: "3.14"
+            PYTORCH_ROCM_TAG: rocm7.1
+            # Same NVIDIA-published Triton nightly feed as the CUDA
+            # job: upstream Triton wheels bundle the AMD backend, so
+            # the pin + replace logic below is shared unchanged.
+            TRITON_NIGHTLY_INDEX_URL: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
+            # HIP honors HIP_VISIBLE_DEVICES; keep CUDA_VISIBLE_DEVICES
+            # alongside it since run-tests.sh exports the latter and
+            # recent ROCm stacks respect both.
             HIP_VISIBLE_DEVICES: "0"
             CUDA_VISIBLE_DEVICES: "0"
-            # Same inductor workarounds as tritonbench's test-gpu.sh:
-            # avoids "Could not find an active GPU backend" in
-            # subprocess workers and speeds up runs.
-            TORCHINDUCTOR_COMPILE_THREADS: "1"
-            TORCHINDUCTOR_MAX_AUTOTUNE: "0"
         steps:
             - uses: actions/checkout@v6
 
             - name: Probe ROCm host
               run: |
                   whoami
-                  docker --version
+                  python3 --version || true
+                  command -v conda || ls /opt/conda/bin/conda /opt/miniconda3/bin/conda "$HOME/miniconda3/bin/conda" 2>/dev/null || true
                   rocm-smi 2>/dev/null || true
+                  cat /opt/rocm/.info/version 2>/dev/null || true
                   rocminfo 2>/dev/null | grep -m4 -E "Marketing Name|gfx" || true
 
-            - name: Pull ROCm test image
+            - name: Install Miniconda (if missing)
+              # The runner host has system Python but no conda (probed
+              # 2026-09-07). Install to $HOME (no sudo needed) and
+              # export CONDA_HOME for the setup step below. Same
+              # installer approach as .ci/setup.sh, user-local path.
               run: |
-                  # Public package: anonymous pull works, but authenticate
-                  # to avoid rate limits (best-effort, non-fatal).
-                  echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin || true
-                  docker pull "${ROCM_IMAGE}"
-                  # Record the exact digest in the log so any green run
-                  # is reproducible even though the tag floats.
-                  docker inspect --format='image digest: {{index .RepoDigests 0}}' "${ROCM_IMAGE}"
-
-            - name: Run tests in ROCm container
-              run: |
-                  # GPU passthrough flags copied from tritonbench's
-                  # _linux-test-mi350.yml (same runner pool). The
-                  # gha-gpu-isolation-settings env file exists on these
-                  # hosts; skip it gracefully if ever absent.
-                  GPU_FLAGS="--device /dev/kfd --device /dev/dri --security-opt seccomp=unconfined --group-add video"
-                  ENV_FILE=""
-                  if [[ -f /etc/podinfo/gha-gpu-isolation-settings ]]; then
-                      ENV_FILE="--env-file /etc/podinfo/gha-gpu-isolation-settings"
+                  if command -v conda >/dev/null 2>&1 || [[ -x /opt/conda/bin/conda || -x /opt/miniconda3/bin/conda ]]; then
+                      echo "conda already present, skipping install"
+                      exit 0
                   fi
-                  docker run --rm \
-                      $GPU_FLAGS $ENV_FILE \
-                      --ipc=host --shm-size=8g \
-                      -e HIP_VISIBLE_DEVICES -e CUDA_VISIBLE_DEVICES \
-                      -e TORCHINDUCTOR_COMPILE_THREADS -e TORCHINDUCTOR_MAX_AUTOTUNE \
-                      -e TEST_TYPE -e COVERAGE \
-                      -e GITHUB_TOKEN=${{ github.token }} \
-                      -v "$GITHUB_WORKSPACE:/tmp/workspace" \
-                      -w /tmp/workspace \
-                      "${ROCM_IMAGE}" bash -c '
-                          set -e
-                          source /workspace/setup_instance.sh
-                          python -c "import torch, triton; print(f\"torch: {torch.__version__}\"); print(f\"triton: {triton.__version__} from {triton.__file__}\"); print(f\"cuda available (HIP backend): {torch.cuda.is_available()}\")"
-                          # Container runs as root while the checkout is
-                          # owned by the host `runner` user: same
-                          # dubious-ownership story as the NVIDIA jobs,
-                          # fixed the same way (setuptools-scm needs git
-                          # introspection for `pip install -e .`).
-                          git config --global --add safe.directory /tmp/workspace
-                          # Use `python -m pip` (NOT bare `pip`): the
-                          # setup script activates a uv venv whose bin
-                          # dir may not ship pip, in which case bare
-                          # `pip` silently resolves to /opt/venv and
-                          # dependencies land in the wrong interpreter
-                          # (seen 2026-09-07: every zstandard import
-                          # failed with 77 unittest errors).
-                          python -m pip --version >/dev/null 2>&1 || python -m ensurepip --upgrade
-                          # Replace the image's triton (3.8.0) with
-                          # upstream nightly HEAD via the shared
-                          # resolver — same pin logic as the CUDA job.
-                          # The image's triton predates the MI350 LLVM
-                          # segfault fix (triton-lang/triton#10523):
-                          # compiling any autotuned kernel on gfx950
-                          # segfaults (exit 139, seen 2026-09-07). The
-                          # image keeps providing the torch-ROCm stack;
-                          # only the compiler is swapped.
-                          python -m pip uninstall -y pytorch-triton triton 2>/dev/null || true
-                          PY_TAG=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
-                          PIN=$(python /tmp/workspace/.ci/triton_nightly_pin.py --pytag "$PY_TAG" --platform x86_64) || PIN=""
-                          if [[ "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
-                              echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
-                              python -m pip install "triton==$PIN" \
-                                  --extra-index-url "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
-                          else
-                              echo "Resolver did not produce a valid pin (got: '$PIN'); falling back to default"
-                              python -m pip install -U --pre triton \
-                                  --extra-index-url "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
-                          fi
-                          python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
-                          python -m pip install -e "/tmp/workspace/.[test]"
-                          if [[ "${COVERAGE}" == "true" ]]; then
-                              RUNNER="coverage run -m unittest"
-                          else
-                              RUNNER="python -m unittest"
-                          fi
-                          case "${TEST_TYPE}" in
-                              cpu) $RUNNER discover -s tests/cpu -t . -v ;;
-                              cuda|gpu) $RUNNER discover -s tests/gpu -t . -v ;;
-                              *) $RUNNER discover -s tests -t . -v ;;
-                          esac
-                      '
+                  echo "Installing Miniconda to $HOME/miniconda3 ..."
+                  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/Miniconda3-latest-Linux-x86_64.sh
+                  bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -u -p "$HOME/miniconda3"
+                  echo "CONDA_HOME=$HOME/miniconda3" >> "$GITHUB_ENV"
+                  echo "Installed: $("$HOME/miniconda3/bin/conda" --version)"
+
+            - name: Mark workspace as safe for git
+              # Same rationale as the NVIDIA jobs: setuptools-scm needs
+              # git introspection during 'pip install -e .'.
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+            - name: Get daily cache timestamp
+              id: daily-cache
+              run: |
+                  DATE_STAMP=$(date +"%Y-%m-%d")
+                  echo "date=$DATE_STAMP" >> $GITHUB_OUTPUT
+                  echo "Using daily cache stamp: $DATE_STAMP"
+
+            - name: Cache pip dependencies
+              uses: actions/cache@v5
+              with:
+                  # Host-direct run (no container), so pip's cache is
+                  # under the runner user's real HOME — NOT
+                  # /github/home as in the container jobs.
+                  path: ~/.cache/pip
+                  key: ${{ runner.os }}-pip-${{ env.PYTORCH_ROCM_TAG }}-py${{ env.PYTHON_VERSION }}-${{ steps.daily-cache.outputs.date }}
+                  restore-keys: |
+                      ${{ runner.os }}-pip-${{ env.PYTORCH_ROCM_TAG }}-py${{ env.PYTHON_VERSION }}-
+
+            - name: Setup conda env + PyTorch ROCm nightly + Triton nightly
+              env:
+                  # Same as the CUDA job: lets the Triton-nightly
+                  # resolver below authenticate to the GitHub API.
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: |
+                  # Locate conda: PATH first, then CONDA_HOME (set by the
+                  # Miniconda step when it had to install), then the
+                  # well-known prefixes. Fail fast with a clear message
+                  # (the Probe step above shows what the host has).
+                  CONDA_BIN="$(command -v conda 2>/dev/null || true)"
+                  for candidate in "${CONDA_HOME:-}/bin/conda" /opt/conda/bin/conda /opt/miniconda3/bin/conda "$HOME/miniconda3/bin/conda"; do
+                      if [[ -z "$CONDA_BIN" && -x "$candidate" ]]; then
+                          CONDA_BIN="$candidate"
+                      fi
+                  done
+                  if [[ -z "$CONDA_BIN" ]]; then
+                      echo "ERROR: conda not found (PATH, CONDA_HOME, /opt/conda, /opt/miniconda3, ~/miniconda3)."
+                      echo "See the 'Probe ROCm host' step output and either provision conda or extend this search."
+                      exit 1
+                  fi
+                  echo "Using conda: $CONDA_BIN"
+                  eval "$("$CONDA_BIN" shell.bash hook)"
+                  # NOTE: explicitly request `pip`: conda-forge's
+                  # `python` package does NOT pull pip in by default
+                  # (same caveat as .ci/setup.sh).
+                  conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" pip -y -c conda-forge
+                  conda activate "$CONDA_ENV"
+
+                  # PyTorch nightly for ROCm. These are wheel-based
+                  # installs (bundled ROCm user-space libs); only the
+                  # kernel driver comes from the host, so the tag must
+                  # match the host ROCm major version (see job header).
+                  pip install --pre torch torchvision torchaudio \
+                      --index-url "https://download.pytorch.org/whl/nightly/${PYTORCH_ROCM_TAG}"
+                  pip install packaging
+                  python -c "import torch; print(f'torch: {torch.__version__}'); print(f'cuda available (HIP backend): {torch.cuda.is_available()}')"
+
+                  # Replace the pytorch-triton snapshot with the upstream
+                  # Triton nightly (bundles the AMD backend), pinning to
+                  # upstream HEAD via the same resolver as the CUDA job.
+                  pip uninstall -y pytorch-triton triton 2>/dev/null || true
+                  PY_TAG=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
+                  PIN=$(python .ci/triton_nightly_pin.py --pytag "$PY_TAG" --platform x86_64) || PIN=""
+                  if [[ "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
+                      echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
+                      pip install "triton==$PIN" \
+                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
+                  else
+                      echo "Resolver did not produce a valid pin (got: '$PIN'); falling back to default"
+                      pip install -U --pre triton \
+                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
+                  fi
+                  python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
+
+            - name: Install project dependencies
+              run: |
+                  bash .ci/install-project.sh
+
+            - name: Run tests
+              env:
+                  TEST_TYPE: ${{ github.event.inputs.test-type || 'all' }}
+                  COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
+              run: |
+                  bash .ci/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,3 +265,147 @@ jobs:
                   COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
               run: |
                   bash .ci/run-tests.sh
+
+    # ===================================================================
+    # GPU tests on AMD MI350 (gfx950) self-hosted runner, ROCm nightly.
+    #
+    # Architecture: host-direct (NO `container:`). Unlike the NVIDIA
+    # jobs, we do not run inside a container image: ROCm needs
+    # /dev/kfd + /dev/dri device passthrough, and the runner host
+    # already ships a working ROCm stack + driver. This mirrors how
+    # pytorch/pytorch runs its own MI350 CI
+    # (rocm-mi350.yml -> linux.rocm.gpu.gfx950.1, docker-less test
+    # path via _rocm-test.yml).
+    #
+    # Runner: `amd-mi350-runner` is the repo-visible ARC scale set
+    # (ephemeral, 1 job per VM — same isolation semantics as the
+    # g5.4xlarge NVIDIA runners). Fallback, if the scale set is ever
+    # drained, is the shared PyTorch ROCm pool 1-GPU slice:
+    # `linux.rocm.gpu.meta-pytorch.mi350.1` (run-tests.sh only ever
+    # uses a single GPU). gfx942 (MI300X) slices are intentionally
+    # left out until this job is green.
+    #
+    # Gating: `workflow_dispatch`-only while stabilizing. The GPU
+    # self-hosted pool already queues for hours (see the 2.5h queue
+    # on the 2026-09-04 main push); do NOT attach this to
+    # pull_request until it is green several dispatches in a row.
+    #
+    # Known first-run unknown: PYTORCH_ROCM_TAG must match the
+    # runner's ROCm major version. `rocm7.1` is verified to exist as
+    # a nightly channel (see https://download.pytorch.org/whl/nightly/
+    # index, probed 2026-09-07). The Probe step below prints the
+    # host's actual ROCm version — if pip refuses the wheel set,
+    # adjust the tag to match and re-dispatch.
+    # ===================================================================
+    test-rocm-nightly:
+        if: github.event_name == 'workflow_dispatch'
+        runs-on: amd-mi350-runner
+        timeout-minutes: 90
+        env:
+            CONDA_ENV: tritonparse-rocm
+            PYTHON_VERSION: "3.14"
+            PYTORCH_ROCM_TAG: rocm7.1
+            # Same NVIDIA-published Triton nightly feed as the CUDA
+            # job: upstream Triton wheels bundle the AMD backend, so
+            # the pin + replace logic below is shared unchanged.
+            TRITON_NIGHTLY_INDEX_URL: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
+            # HIP honors HIP_VISIBLE_DEVICES; keep CUDA_VISIBLE_DEVICES
+            # alongside it since run-tests.sh exports the latter and
+            # recent ROCm stacks respect both.
+            HIP_VISIBLE_DEVICES: "0"
+            CUDA_VISIBLE_DEVICES: "0"
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Probe ROCm host
+              run: |
+                  whoami
+                  python3 --version || true
+                  command -v conda || ls /opt/conda/bin/conda /opt/miniconda3/bin/conda 2>/dev/null || true
+                  rocm-smi --showid 2>/dev/null || rocm-smi 2>/dev/null || true
+                  rocminfo 2>/dev/null | grep -m4 -E "Marketing Name|gfx" || true
+
+            - name: Mark workspace as safe for git
+              # Same rationale as the NVIDIA jobs: setuptools-scm needs
+              # git introspection during 'pip install -e .'.
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+            - name: Get daily cache timestamp
+              id: daily-cache
+              run: |
+                  DATE_STAMP=$(date +"%Y-%m-%d")
+                  echo "date=$DATE_STAMP" >> $GITHUB_OUTPUT
+                  echo "Using daily cache stamp: $DATE_STAMP"
+
+            - name: Cache pip dependencies
+              uses: actions/cache@v5
+              with:
+                  # Host-direct run (no container), so pip's cache is
+                  # under the runner user's real HOME — NOT
+                  # /github/home as in the container jobs.
+                  path: ~/.cache/pip
+                  key: ${{ runner.os }}-pip-${{ env.PYTORCH_ROCM_TAG }}-py${{ env.PYTHON_VERSION }}-${{ steps.daily-cache.outputs.date }}
+                  restore-keys: |
+                      ${{ runner.os }}-pip-${{ env.PYTORCH_ROCM_TAG }}-py${{ env.PYTHON_VERSION }}-
+
+            - name: Setup conda env + PyTorch ROCm nightly + Triton nightly
+              env:
+                  # Same as the CUDA job: lets the Triton-nightly
+                  # resolver below authenticate to the GitHub API.
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: |
+                  # Locate conda: PATH first, then the well-known
+                  # prefixes. Fail fast with a clear message (the
+                  # Probe step above shows what the host has).
+                  CONDA_BIN="$(command -v conda 2>/dev/null || true)"
+                  for candidate in /opt/conda/bin/conda /opt/miniconda3/bin/conda; do
+                      if [[ -z "$CONDA_BIN" && -x "$candidate" ]]; then
+                          CONDA_BIN="$candidate"
+                      fi
+                  done
+                  if [[ -z "$CONDA_BIN" ]]; then
+                      echo "ERROR: conda not found on PATH or in /opt/conda, /opt/miniconda3."
+                      echo "See the 'Probe ROCm host' step output and either provision conda or extend this search."
+                      exit 1
+                  fi
+                  echo "Using conda: $CONDA_BIN"
+                  eval "$("$CONDA_BIN" shell.bash hook)"
+                  conda create -n "$CONDA_ENV" python="$PYTHON_VERSION" -y -c conda-forge
+                  conda activate "$CONDA_ENV"
+
+                  # PyTorch nightly for ROCm. These are wheel-based
+                  # installs (bundled ROCm user-space libs); only the
+                  # kernel driver comes from the host, so the tag must
+                  # match the host ROCm major version (see job header).
+                  pip install --pre torch torchvision torchaudio \
+                      --index-url "https://download.pytorch.org/whl/nightly/${PYTORCH_ROCM_TAG}"
+                  pip install packaging
+                  python -c "import torch; print(f'torch: {torch.__version__}'); print(f'cuda available (HIP backend): {torch.cuda.is_available()}')"
+
+                  # Replace the pytorch-triton snapshot with the upstream
+                  # Triton nightly (bundles the AMD backend), pinning to
+                  # upstream HEAD via the same resolver as the CUDA job.
+                  pip uninstall -y pytorch-triton triton 2>/dev/null || true
+                  PY_TAG=$(python -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
+                  PIN=$(python .ci/triton_nightly_pin.py --pytag "$PY_TAG" --platform x86_64) || PIN=""
+                  if [[ "$PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+git[0-9a-f]+$ ]]; then
+                      echo "Pinning Triton nightly to upstream HEAD: triton==$PIN"
+                      pip install "triton==$PIN" \
+                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
+                  else
+                      echo "Resolver did not produce a valid pin (got: '$PIN'); falling back to default"
+                      pip install -U --pre triton \
+                          --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
+                  fi
+                  python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
+
+            - name: Install project dependencies
+              run: |
+                  bash .ci/install-project.sh
+
+            - name: Run tests
+              env:
+                  TEST_TYPE: ${{ github.event.inputs.test-type || 'all' }}
+                  COVERAGE: ${{ github.event.inputs.coverage || 'false' }}
+              run: |
+                  bash .ci/run-tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -366,7 +366,15 @@ jobs:
                           # fixed the same way (setuptools-scm needs git
                           # introspection for `pip install -e .`).
                           git config --global --add safe.directory /tmp/workspace
-                          pip install -e "/tmp/workspace/.[test]"
+                          # Use `python -m pip` (NOT bare `pip`): the
+                          # setup script activates a uv venv whose bin
+                          # dir may not ship pip, in which case bare
+                          # `pip` silently resolves to /opt/venv and
+                          # dependencies land in the wrong interpreter
+                          # (seen 2026-09-07: every zstandard import
+                          # failed with 77 unittest errors).
+                          python -m pip --version >/dev/null 2>&1 || python -m ensurepip --upgrade
+                          python -m pip install -e "/tmp/workspace/.[test]"
                           if [[ "${COVERAGE}" == "true" ]]; then
                               RUNNER="coverage run -m unittest"
                           else

--- a/tests/cpu/test_device_arch.py
+++ b/tests/cpu/test_device_arch.py
@@ -1,0 +1,55 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+"""CPU tests for GPU-architecture helpers in tests.test_utils.
+
+`is_amd_gpu()` / `is_nvidia_gpu()` drive backend-exclusive skips
+(e.g. SASS assertions are NVIDIA-only, AMD e2e is AMD-only), so a
+wrong answer here silently disables or breaks tests per-arch. torch
+is mocked: no GPU needed.
+"""
+
+import unittest
+from unittest import mock
+
+from tests.test_utils import is_amd_gpu, is_nvidia_gpu
+
+
+def _torch_mock(*, available, hip):
+    torch_mock = mock.MagicMock()
+    torch_mock.cuda.is_available.return_value = available
+    torch_mock.version.hip = hip
+    torch_mock.version.cuda = "12.8" if hip is None else None
+    return torch_mock
+
+
+class TestDeviceArchHelpers(unittest.TestCase):
+    def test_rocm_build_with_gpu_is_amd(self):
+        with mock.patch(
+            "tests.test_utils.torch", _torch_mock(available=True, hip="7.1")
+        ):
+            self.assertTrue(is_amd_gpu())
+            self.assertFalse(is_nvidia_gpu())
+
+    def test_cuda_build_with_gpu_is_nvidia(self):
+        with mock.patch(
+            "tests.test_utils.torch", _torch_mock(available=True, hip=None)
+        ):
+            self.assertFalse(is_amd_gpu())
+            self.assertTrue(is_nvidia_gpu())
+
+    def test_no_gpu_is_neither(self):
+        with mock.patch(
+            "tests.test_utils.torch", _torch_mock(available=False, hip="7.1")
+        ):
+            self.assertFalse(is_amd_gpu())
+            self.assertFalse(is_nvidia_gpu())
+
+    def test_lookup_error_is_neither(self):
+        torch_mock = mock.MagicMock()
+        torch_mock.cuda.is_available.side_effect = RuntimeError("no driver")
+        with mock.patch("tests.test_utils.torch", torch_mock):
+            self.assertFalse(is_amd_gpu())
+            self.assertFalse(is_nvidia_gpu())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cpu/test_disasm.py
+++ b/tests/cpu/test_disasm.py
@@ -1,0 +1,74 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+"""CPU tests for tritonparse.tools.disasm availability checks.
+
+`is_nvdisasm_available()` must reflect whether the nvdisasm binary can
+actually run — not just whether triton's knob holds a path string. On
+AMD/ROCm hosts the knob default can be set while the NVIDIA-only tool
+is absent; reporting True there enables SASS dumping that silently
+produces nothing and breaks tests asserting on SASS content.
+"""
+
+import os
+import stat
+import tempfile
+import unittest
+from unittest import mock
+
+from tritonparse.tools import disasm
+
+
+def _knobs_with_path(path):
+    knobs = mock.MagicMock()
+    knobs.nvidia.nvdisasm.path = path
+    return knobs
+
+
+class TestIsNvdisasmAvailable(unittest.TestCase):
+    def test_empty_path_is_unavailable(self):
+        for path in ("", None):
+            with (
+                self.subTest(path=path),
+                mock.patch("triton.knobs", _knobs_with_path(path)),
+            ):
+                self.assertFalse(disasm.is_nvdisasm_available())
+
+    def test_missing_file_is_unavailable(self):
+        with mock.patch(
+            "triton.knobs",
+            _knobs_with_path("/nonexistent-dir/nvdisasm"),
+        ):
+            self.assertFalse(disasm.is_nvdisasm_available())
+
+    def test_non_executable_file_is_unavailable(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        with mock.patch("triton.knobs", _knobs_with_path(path)):
+            self.assertFalse(disasm.is_nvdisasm_available())
+
+    def test_executable_file_is_available(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        with mock.patch("triton.knobs", _knobs_with_path(path)):
+            self.assertTrue(disasm.is_nvdisasm_available())
+
+    def test_bare_name_resolved_via_path(self):
+        with (
+            mock.patch("triton.knobs", _knobs_with_path("nvdisasm")),
+            mock.patch("shutil.which", return_value=None) as which,
+        ):
+            self.assertFalse(disasm.is_nvdisasm_available())
+            which.assert_called_once_with("nvdisasm")
+
+    def test_knob_lookup_error_is_unavailable(self):
+        knobs = mock.MagicMock()
+        type(knobs).nvidia = mock.PropertyMock(side_effect=RuntimeError("no knobs"))
+        with mock.patch("triton.knobs", knobs):
+            self.assertFalse(disasm.is_nvdisasm_available())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gpu/test_structured_logging.py
+++ b/tests/gpu/test_structured_logging.py
@@ -24,7 +24,7 @@ import triton.language as tl  # @manual=//triton:triton
 import tritonparse.parse.utils
 import tritonparse.structured_logging
 from parameterized import parameterized  # @manual
-from tests.test_utils import GPUTestBase
+from tests.test_utils import GPUTestBase, is_amd_gpu
 from triton.compiler import ASTSource, IRSource  # @manual=//triton:triton
 from triton.knobs import CompileTimes  # @manual=//triton:triton
 from tritonparse.shared_vars import TEST_KEEP_OUTPUT
@@ -306,15 +306,18 @@ class TestStructuredLogging(GPUTestBase):
             f"Expected 2 'launch' events, found {event_counts['launch']}",
         )
 
-        # Conditionally verify SASS content based on nvdisasm availability
-        if nvdisasm_available:
+        # Conditionally verify SASS content: SASS is NVIDIA-only (derived
+        # from cubins via nvdisasm). The tool binary ships inside the
+        # triton wheel on every backend, so its mere presence cannot gate
+        # this — also require a non-AMD GPU.
+        if nvdisasm_available and not is_amd_gpu():
             self.assertTrue(
                 event_counts["sass_found"],
                 "SASS content was not found in compilation events",
             )
             print("✓ Successfully verified SASS extraction functionality")
         else:
-            print("⚠️  SASS verification skipped: nvdisasm not available")
+            print("⚠️  SASS verification skipped: nvdisasm not available or AMD GPU")
 
         print(
             "✓ Verified correct event type counts: 1 unique compilation hash, 2 launch events"
@@ -366,14 +369,15 @@ class TestStructuredLogging(GPUTestBase):
                     break
 
             # Conditionally verify SASS content is preserved in parsed output
-            if nvdisasm_available:
+            # (NVIDIA-only; see above).
+            if nvdisasm_available and not is_amd_gpu():
                 self.assertTrue(
                     sass_found_in_parsed,
                     "SASS content was not preserved in parsed output",
                 )
             else:
                 print(
-                    "⚠️  SASS preservation verification skipped: nvdisasm not available"
+                    "⚠️  SASS preservation verification skipped: nvdisasm not available or AMD GPU"
                 )
 
         finally:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,35 @@ requires_gpu = unittest.skipUnless(torch.cuda.is_available(), "GPU not available
 skip_in_fbcode = unittest.skipIf(is_fbcode(), "Skip in internal FB environment")
 
 
+def is_amd_gpu() -> bool:
+    """True when an AMD GPU is present and usable (ROCm/HIP torch build).
+
+    Detected from the torch build flag plus cuda availability — no GPU
+    context is initialized, so this is safe to evaluate at import /
+    collection time (decorators below run then). Any lookup failure
+    means "not AMD". Mirrors tritonbench's is_hip() usage.
+    """
+    try:
+        return bool(torch.cuda.is_available() and torch.version.hip is not None)
+    except Exception:
+        return False
+
+
+def is_nvidia_gpu() -> bool:
+    """True when an NVIDIA GPU is present and usable (CUDA torch build)."""
+    try:
+        return bool(torch.cuda.is_available() and torch.version.hip is None)
+    except Exception:
+        return False
+
+
+# Backend-exclusive tests: the whole suite runs on every GPU job and
+# each arch skips what it cannot produce (same pattern as requires_gpu).
+skip_if_amd = unittest.skipIf(is_amd_gpu(), "NVIDIA-only test")
+
+skip_unless_amd = unittest.skipUnless(is_amd_gpu(), "AMD-only test")
+
+
 # =============================================================================
 # Helper functions
 # =============================================================================

--- a/tritonparse/tools/disasm.py
+++ b/tritonparse/tools/disasm.py
@@ -1,5 +1,7 @@
 #  Copyright (c) Meta Platforms, Inc. and affiliates.
+import os
 import re
+import shutil
 import subprocess
 
 # Regex patterns for nvdisasm output
@@ -13,13 +15,21 @@ def path_to_nvdisasm():
 
 
 def is_nvdisasm_available():
+    """Return True only if the nvdisasm binary is actually executable.
+
+    The triton knob can hold a path string even on machines where the
+    tool is absent (e.g. AMD/ROCm hosts that still ship the NVIDIA
+    knob defaults), so a truthy knob alone is not sufficient.
+    """
     try:
-        if path_to_nvdisasm():
-            return True
-        else:
-            return False
+        path = path_to_nvdisasm()
     except RuntimeError:
         return False
+    if not path:
+        return False
+    if os.path.dirname(path):
+        return os.path.isfile(path) and os.access(path, os.X_OK)
+    return shutil.which(path) is not None
 
 
 def extract(file_path):


### PR DESCRIPTION
Stacked on #427 (shares its branch history; review the last commit only). Replaces the silent unpinned-triton fallback with exit 1 in both nightly jobs (CUDA test-from-nightly + ROCm test-rocm-nightly): dispatch 34153093645 silently tested triton 3.8.0 instead of nightly HEAD because the resolver returned empty. Re-dispatch once the feed catches up.