### PR TITLE
Accept Manifold URLs as `tritonparse diff` inputs

### DIFF
--- a/tests/cpu/diff/test_input_resolver.py
+++ b/tests/cpu/diff/test_input_resolver.py
@@ -1,0 +1,49 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Tests for resolving diff inputs to local files."""
+
+import unittest
+
+# Any fetchable URL works here; these tests never dereference it.
+REMOTE_URL = "https://example.com/logs/t.ndjson.gz"
+
+
+class TestResolveInput(unittest.TestCase):
+    def test_local_path_passes_through_unlinkable(self) -> None:
+        """Local inputs are untouched and yield no shareable URL."""
+        from tritonparse.diff.core.input_resolver import resolve_input
+
+        resolved = resolve_input("/tmp/trace.ndjson")
+        self.assertEqual(resolved.local_path, "/tmp/trace.ndjson")
+        self.assertEqual(resolved.display, "/tmp/trace.ndjson")
+        self.assertIsNone(resolved.json_url)
+
+
+class TestGenerateOutputPath(unittest.TestCase):
+    def test_local_input_writes_beside_input(self) -> None:
+        from tritonparse.diff.cli import _generate_output_path
+        from tritonparse.diff.core.input_resolver import ResolvedInput
+
+        local = ResolvedInput(
+            local_path="/a/b/trace.ndjson", display="/a/b/trace.ndjson"
+        )
+        self.assertEqual(_generate_output_path(local), "/a/b/trace_diff.ndjson")
+
+    def test_gz_suffix_preserved(self) -> None:
+        from tritonparse.diff.cli import _generate_output_path
+        from tritonparse.diff.core.input_resolver import ResolvedInput
+
+        local = ResolvedInput(local_path="/a/t.ndjson.gz", display="/a/t.ndjson.gz")
+        self.assertEqual(_generate_output_path(local), "/a/t_diff.ndjson.gz")
+
+    def test_remote_input_writes_to_cwd_not_tempdir(self) -> None:
+        """Output must not land in the temp dir, which is deleted on exit."""
+        from tritonparse.diff.cli import _generate_output_path
+        from tritonparse.diff.core.input_resolver import ResolvedInput
+
+        remote = ResolvedInput(
+            local_path="/tmp/tritonparse_diff_xyz/bucket/tree/logs/t.ndjson.gz",
+            display="remote://bucket/tree/logs/t.ndjson.gz",
+            json_url=REMOTE_URL,
+        )
+        self.assertEqual(_generate_output_path(remote), "t_diff.ndjson.gz")

--- a/tritonparse/diff/cli.py
+++ b/tritonparse/diff/cli.py
@@ -20,6 +20,7 @@ from tritonparse.diff.core.event_matcher import (
     match_events_by_index,
     match_events_by_kernel,
 )
+from tritonparse.diff.core.input_resolver import is_remote, resolve_input, ResolvedInput
 from tritonparse.diff.output import (
     append_diff_to_file,
     ConsolidatedDiffWriter,
@@ -33,12 +34,24 @@ from tritonparse.tp_logger import get_logger
 logger = get_logger("diff.cli")
 
 
+def _input_help() -> str:
+    """Help for the positional input, listing only sources this build accepts."""
+    sources = "local ndjson path"
+    if is_fbcode():
+        from tritonparse.diff.fb.remote_input import REMOTE_SOURCE_HELP
+
+        sources += f", {REMOTE_SOURCE_HELP}"
+    return (
+        f"Trace source(s): {sources}. One for single-file mode, two for dual-file mode."
+    )
+
+
 def _add_diff_args(parser: argparse.ArgumentParser) -> None:
     """Add arguments for the diff subcommand."""
     parser.add_argument(
         "input",
         nargs="+",
-        help="Path(s) to ndjson file(s). One file for single-file mode, two for dual-file mode.",
+        help=_input_help(),
     )
     parser.add_argument(
         "--events",
@@ -139,21 +152,33 @@ def _parse_event_indices(events_str: str) -> tuple[int, int]:
         ) from e
 
 
-def _generate_output_path(input_path: str) -> str:
-    """Generate default output path from input path.
+def _generate_output_path(resolved: ResolvedInput) -> str:
+    """Generate default output path for a resolved input.
 
-    Args:
-        input_path: Path to input file
+    Remote inputs live in a temp dir that is deleted on exit, so their output
+    is written to the basename in the current directory instead.
 
     Returns:
         Output path with _diff suffix before extension
     """
+    input_path = resolved.local_path
+    if resolved.json_url is not None:
+        input_path = os.path.basename(input_path)
     base, ext = os.path.splitext(input_path)
     if ext == ".gz":
         # Handle .ndjson.gz
         base2, ext2 = os.path.splitext(base)
         return f"{base2}_diff{ext2}{ext}"
     return f"{base}_diff{ext}"
+
+
+def _resolve_inputs(input_paths: list[str]) -> list[ResolvedInput]:
+    """Fetch any remote inputs and report what was resolved."""
+    resolved = [resolve_input(path) for path in input_paths]
+    for original, item in zip(input_paths, resolved):
+        if item.json_url is not None:
+            logger.info(f"Resolved {original} -> {item.local_path}")
+    return resolved
 
 
 def trace_diff_command(
@@ -168,7 +193,7 @@ def trace_diff_command(
     """Run trace-level diff comparing all kernels across two trace files.
 
     Args:
-        input_paths: Exactly 2 input ndjson file paths.
+        input_paths: Exactly 2 trace sources (local paths or remote refs).
         output: Optional output file path.
         quiet: If True, suppress CLI output.
         tensor_values: If True, compare tensor values.
@@ -183,16 +208,18 @@ def trace_diff_command(
     if len(input_paths) != 2:
         raise ValueError("--trace requires exactly 2 input files")
 
+    resolved_a, resolved_b = _resolve_inputs(input_paths)
+
     # Load events
-    events_a = load_events(input_paths[0])
-    events_b = load_events(input_paths[1])
+    events_a = load_events(resolved_a.local_path)
+    events_b = load_events(resolved_b.local_path)
 
     # Run trace diff
     engine = TraceDiffEngine(
         events_a,
         events_b,
-        trace_path_a=input_paths[0],
-        trace_path_b=input_paths[1],
+        trace_path_a=resolved_a.display,
+        trace_path_b=resolved_b.display,
         tensor_values=tensor_values,
         atol=atol,
         rtol=rtol,
@@ -265,7 +292,7 @@ def trace_diff_command(
             logger.warning(f"AI analysis setup failed: {e}")
 
     # Write output
-    output_path = output or _generate_output_path(input_paths[0])
+    output_path = output or _generate_output_path(resolved_a)
     writer = ConsolidatedDiffWriter()
     writer.add_trace_diff(result, events_a, events_b)
     writer.write(output_path)
@@ -292,7 +319,7 @@ def diff_command(
     Main function for the diff command.
 
     Args:
-        input_paths: List of input ndjson file paths (1 or 2 files)
+        input_paths: Trace sources, 1 or 2 (local paths or remote refs)
         events: Comma-separated event indices to compare (e.g., "0,1")
         kernel: Optional kernel name to filter by
         output: Optional output file path
@@ -330,15 +357,28 @@ def diff_command(
             "At most 2 input files allowed (single-file or dual-file mode)"
         )
 
+    # Checked before resolving: a remote input is staged in a temp dir that
+    # is deleted on exit, so there is nothing durable to append to. Failing
+    # here avoids downloading and diffing multi-megabyte traces first.
+    if in_place and is_remote(input_paths[0]):
+        raise ValueError(
+            "--in-place cannot be used with a remote input: the downloaded "
+            f"copy of {input_paths[0]} is temporary. Use --output."
+        )
+
     # Load events from first file
-    input_path_a = input_paths[0]
-    all_events_a = load_events(input_path_a)
+    resolved = _resolve_inputs(input_paths)
+    resolved_a = resolved[0]
+    input_path_a = resolved_a.display
+    all_events_a = load_events(resolved_a.local_path)
 
     # Handle dual-file mode
     if len(input_paths) == 2:
-        input_path_b = input_paths[1]
-        all_events_b = load_events(input_path_b)
+        resolved_b = resolved[1]
+        input_path_b = resolved_b.display
+        all_events_b = load_events(resolved_b.local_path)
     else:
+        resolved_b = resolved_a
         input_path_b = input_path_a
         all_events_b = all_events_a
 
@@ -496,11 +536,11 @@ def diff_command(
 
     # Write output
     if in_place:
-        append_diff_to_file(input_path_a, diff_event)
+        append_diff_to_file(resolved_a.local_path, diff_event)
         if not quiet:
             logger.info(f"Appended diff event to: {input_path_a}")
     else:
-        output_path = output or _generate_output_path(input_path_a)
+        output_path = output or _generate_output_path(resolved_a)
         writer = ConsolidatedDiffWriter()
         writer.add_diff(result, comp_a, comp_b)
         writer.write(output_path)

--- a/tritonparse/diff/core/input_resolver.py
+++ b/tritonparse/diff/core/input_resolver.py
@@ -1,0 +1,50 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Resolve a diff input to a local file, plus a shareable URL when one exists.
+
+OSS accepts local paths only. In fbcode the work is delegated to
+``tritonparse.diff.fb.input_resolver``, which additionally understands remote
+trace references and can fetch them; that module is not synced to GitHub.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tritonparse.shared_vars import is_fbcode
+
+
+@dataclass(frozen=True)
+class ResolvedInput:
+    """A diff input that has been made readable on the local filesystem."""
+
+    # Path to read events from.
+    local_path: str
+    # Original user-supplied string, for display.
+    display: str
+    # Browser-fetchable URL, when one exists for this input. None for purely
+    # local inputs, which cannot be linked.
+    json_url: str | None = None
+
+
+def is_remote(source: str) -> bool:
+    """Whether this input has to be fetched before it can be read.
+
+    Lets callers reject an unsupported combination before paying for the
+    fetch. Always False in OSS, which accepts local paths only.
+    """
+    if not is_fbcode():
+        return False
+    from tritonparse.diff.fb.input_resolver import is_remote as fb_is_remote
+
+    return fb_is_remote(source)
+
+
+def resolve_input(source: str) -> ResolvedInput:
+    """Resolve one diff input to something readable on this filesystem."""
+    if is_fbcode():
+        from tritonparse.diff.fb.input_resolver import resolve_input as fb_resolve
+
+        return fb_resolve(source)
+    return ResolvedInput(local_path=source, display=source)


### PR DESCRIPTION
Summary:
Third of four diffs adding Manifold-URL inputs and File Diff link output to
`tritonparse diff`. This is the user-visible half of the feature request: pass
two Manifold URLs, get a comparison.

- `tritonparse/diff/fb/manifold_io.py` — `download()` fetches a blob via
  `ManifoldClient.sync_get` into a process-lifetime temp dir, cached by
  `RemoteRef`. Nested under bucket + dirname so two traces sharing a basename
  (the common case — same filename under different tmp dirs) do not collide.
- `tritonparse/diff/core/input_resolver.py` — the OSS-visible seam: the
  `ResolvedInput(local_path, display, json_url)` container plus `resolve_input()`
  and `is_remote()`, which delegate to the fb implementation under `is_fbcode()`
  and otherwise treat every input as a local path. No Manifold vocabulary.
- `tritonparse/diff/fb/input_resolver.py` — the Manifold-aware implementation.
  Local paths pass through untouched; Manifold refs are downloaded and carry the
  CDN URL that the next diff uses to build links.
- `diff/cli.py` resolves both inputs before `load_events()`.

Per review, everything that encodes internal infrastructure lives under
`diff/fb/`, so the OSS GitHub mirror never sees it. `diff/cli.py` has to stay
shared, so its user-facing text is environment-aware: the `input` help lists the
remote URL forms only under `is_fbcode()`, and its docstrings and the
`--in-place` rejection now say "remote" rather than naming Manifold.

Verified by grep: no `manifold` import, and no Manifold/interncache vocabulary,
anywhere under `diff/` outside `diff/fb/` — see `.claude/rules/dual-path.md`.

Two things resolution would otherwise have broken, both handled here:
- `--in-place` on a Manifold input would append to a temp file that is deleted
  on exit. Now rejected up front, before any download, so the command fails
  instantly instead of after pulling and diffing multi-megabyte traces.
- The default output path would land inside the temp dir. Remote inputs now
  write to the basename in the current directory.

Reviewed By: FindHao

Differential Revision: D118832011


