### PR TITLE
Print a File Diff link for every `tritonparse diff`

### DIFF
--- a/tests/cpu/diff/test_input_resolver.py
+++ b/tests/cpu/diff/test_input_resolver.py
@@ -19,6 +19,17 @@ class TestResolveInput(unittest.TestCase):
         self.assertIsNone(resolved.json_url)
 
 
+class TestWantsLinks(unittest.TestCase):
+    """Uploading is gated on a link actually being printed."""
+
+    def test_gating(self) -> None:
+        from tritonparse.diff.cli import _wants_links
+
+        self.assertTrue(_wants_links(no_url=False, quiet=False))
+        self.assertFalse(_wants_links(no_url=True, quiet=False))
+        self.assertFalse(_wants_links(no_url=False, quiet=True))
+
+
 class TestGenerateOutputPath(unittest.TestCase):
     def test_local_input_writes_beside_input(self) -> None:
         from tritonparse.diff.cli import _generate_output_path

--- a/tests/cpu/diff/test_input_resolver.py
+++ b/tests/cpu/diff/test_input_resolver.py
@@ -1,0 +1,49 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Tests for resolving diff inputs to local files."""
+
+import unittest
+
+# Any fetchable URL works here; these tests never dereference it.
+REMOTE_URL = "https://example.com/logs/t.ndjson.gz"
+
+
+class TestResolveInput(unittest.TestCase):
+    def test_local_path_passes_through_unlinkable(self) -> None:
+        """Local inputs are untouched and yield no shareable URL."""
+        from tritonparse.diff.core.input_resolver import resolve_input
+
+        resolved = resolve_input("/tmp/trace.ndjson")
+        self.assertEqual(resolved.local_path, "/tmp/trace.ndjson")
+        self.assertEqual(resolved.display, "/tmp/trace.ndjson")
+        self.assertIsNone(resolved.json_url)
+
+
+class TestGenerateOutputPath(unittest.TestCase):
+    def test_local_input_writes_beside_input(self) -> None:
+        from tritonparse.diff.cli import _generate_output_path
+        from tritonparse.diff.core.input_resolver import ResolvedInput
+
+        local = ResolvedInput(
+            local_path="/a/b/trace.ndjson", display="/a/b/trace.ndjson"
+        )
+        self.assertEqual(_generate_output_path(local), "/a/b/trace_diff.ndjson")
+
+    def test_gz_suffix_preserved(self) -> None:
+        from tritonparse.diff.cli import _generate_output_path
+        from tritonparse.diff.core.input_resolver import ResolvedInput
+
+        local = ResolvedInput(local_path="/a/t.ndjson.gz", display="/a/t.ndjson.gz")
+        self.assertEqual(_generate_output_path(local), "/a/t_diff.ndjson.gz")
+
+    def test_remote_input_writes_to_cwd_not_tempdir(self) -> None:
+        """Output must not land in the temp dir, which is deleted on exit."""
+        from tritonparse.diff.cli import _generate_output_path
+        from tritonparse.diff.core.input_resolver import ResolvedInput
+
+        remote = ResolvedInput(
+            local_path="/tmp/tritonparse_diff_xyz/bucket/tree/logs/t.ndjson.gz",
+            display="remote://bucket/tree/logs/t.ndjson.gz",
+            json_url=REMOTE_URL,
+        )
+        self.assertEqual(_generate_output_path(remote), "t_diff.ndjson.gz")

--- a/tritonparse/cli.py
+++ b/tritonparse/cli.py
@@ -200,6 +200,9 @@ def main():
             rtol=args.rtol,
             trace=args.trace,
             ai=args.ai,
+            no_url=args.no_url,
+            max_urls=args.max_urls,
+            no_share=args.no_share,
         )
     elif args.func == "bisect":
         _validate_bisect_args(args, bisect_parser)

--- a/tritonparse/diff/cli.py
+++ b/tritonparse/diff/cli.py
@@ -20,6 +20,7 @@ from tritonparse.diff.core.event_matcher import (
     match_events_by_index,
     match_events_by_kernel,
 )
+from tritonparse.diff.core.input_resolver import is_remote, resolve_input, ResolvedInput
 from tritonparse.diff.output import (
     append_diff_to_file,
     ConsolidatedDiffWriter,
@@ -33,12 +34,24 @@ from tritonparse.tp_logger import get_logger
 logger = get_logger("diff.cli")
 
 
+def _input_help() -> str:
+    """Help for the positional input, listing only sources this build accepts."""
+    sources = "local ndjson path"
+    if is_fbcode():
+        from tritonparse.diff.fb.remote_input import REMOTE_SOURCE_HELP
+
+        sources += f", {REMOTE_SOURCE_HELP}"
+    return (
+        f"Trace source(s): {sources}. One for single-file mode, two for dual-file mode."
+    )
+
+
 def _add_diff_args(parser: argparse.ArgumentParser) -> None:
     """Add arguments for the diff subcommand."""
     parser.add_argument(
         "input",
         nargs="+",
-        help="Path(s) to ndjson file(s). One file for single-file mode, two for dual-file mode.",
+        help=_input_help(),
     )
     parser.add_argument(
         "--events",
@@ -139,21 +152,33 @@ def _parse_event_indices(events_str: str) -> tuple[int, int]:
         ) from e
 
 
-def _generate_output_path(input_path: str) -> str:
-    """Generate default output path from input path.
+def _generate_output_path(resolved: ResolvedInput) -> str:
+    """Generate default output path for a resolved input.
 
-    Args:
-        input_path: Path to input file
+    Remote inputs live in a temp dir that is deleted on exit, so their output
+    is written to the basename in the current directory instead.
 
     Returns:
         Output path with _diff suffix before extension
     """
+    input_path = resolved.local_path
+    if resolved.json_url is not None:
+        input_path = os.path.basename(input_path)
     base, ext = os.path.splitext(input_path)
     if ext == ".gz":
         # Handle .ndjson.gz
         base2, ext2 = os.path.splitext(base)
         return f"{base2}_diff{ext2}{ext}"
     return f"{base}_diff{ext}"
+
+
+def _resolve_inputs(input_paths: list[str]) -> list[ResolvedInput]:
+    """Fetch any remote inputs and report what was resolved."""
+    resolved = [resolve_input(path) for path in input_paths]
+    for original, item in zip(input_paths, resolved):
+        if item.json_url is not None:
+            logger.info(f"Resolved {original} -> {item.local_path}")
+    return resolved
 
 
 def trace_diff_command(
@@ -168,7 +193,7 @@ def trace_diff_command(
     """Run trace-level diff comparing all kernels across two trace files.
 
     Args:
-        input_paths: Exactly 2 input ndjson file paths.
+        input_paths: Exactly 2 trace sources (local paths or remote refs).
         output: Optional output file path.
         quiet: If True, suppress CLI output.
         tensor_values: If True, compare tensor values.
@@ -183,16 +208,18 @@ def trace_diff_command(
     if len(input_paths) != 2:
         raise ValueError("--trace requires exactly 2 input files")
 
+    resolved_a, resolved_b = _resolve_inputs(input_paths)
+
     # Load events
-    events_a = load_events(input_paths[0])
-    events_b = load_events(input_paths[1])
+    events_a = load_events(resolved_a.local_path)
+    events_b = load_events(resolved_b.local_path)
 
     # Run trace diff
     engine = TraceDiffEngine(
         events_a,
         events_b,
-        trace_path_a=input_paths[0],
-        trace_path_b=input_paths[1],
+        trace_path_a=resolved_a.display,
+        trace_path_b=resolved_b.display,
         tensor_values=tensor_values,
         atol=atol,
         rtol=rtol,
@@ -265,7 +292,7 @@ def trace_diff_command(
             logger.warning(f"AI analysis setup failed: {e}")
 
     # Write output
-    output_path = output or _generate_output_path(input_paths[0])
+    output_path = output or _generate_output_path(resolved_a)
     writer = ConsolidatedDiffWriter()
     writer.add_trace_diff(result, events_a, events_b)
     writer.write(output_path)
@@ -292,7 +319,7 @@ def diff_command(
     Main function for the diff command.
 
     Args:
-        input_paths: List of input ndjson file paths (1 or 2 files)
+        input_paths: Trace sources, 1 or 2 (local paths or remote refs)
         events: Comma-separated event indices to compare (e.g., "0,1")
         kernel: Optional kernel name to filter by
         output: Optional output file path
@@ -330,15 +357,28 @@ def diff_command(
             "At most 2 input files allowed (single-file or dual-file mode)"
         )
 
+    # Checked before resolving: a remote input is staged in a temp dir that
+    # is deleted on exit, so there is nothing durable to append to. Failing
+    # here avoids downloading and diffing multi-megabyte traces first.
+    if in_place and is_remote(input_paths[0]):
+        raise ValueError(
+            "--in-place cannot be used with a remote input: the downloaded "
+            f"copy of {input_paths[0]} is temporary. Use --output."
+        )
+
     # Load events from first file
-    input_path_a = input_paths[0]
-    all_events_a = load_events(input_path_a)
+    resolved = _resolve_inputs(input_paths)
+    resolved_a = resolved[0]
+    input_path_a = resolved_a.display
+    all_events_a = load_events(resolved_a.local_path)
 
     # Handle dual-file mode
     if len(input_paths) == 2:
-        input_path_b = input_paths[1]
-        all_events_b = load_events(input_path_b)
+        resolved_b = resolved[1]
+        input_path_b = resolved_b.display
+        all_events_b = load_events(resolved_b.local_path)
     else:
+        resolved_b = resolved_a
         input_path_b = input_path_a
         all_events_b = all_events_a
 
@@ -496,11 +536,11 @@ def diff_command(
 
     # Write output
     if in_place:
-        append_diff_to_file(input_path_a, diff_event)
+        append_diff_to_file(resolved_a.local_path, diff_event)
         if not quiet:
             logger.info(f"Appended diff event to: {input_path_a}")
     else:
-        output_path = output or _generate_output_path(input_path_a)
+        output_path = output or _generate_output_path(resolved_a)
         writer = ConsolidatedDiffWriter()
         writer.add_diff(result, comp_a, comp_b)
         writer.write(output_path)

--- a/tritonparse/diff/cli.py
+++ b/tritonparse/diff/cli.py
@@ -20,7 +20,12 @@ from tritonparse.diff.core.event_matcher import (
     match_events_by_index,
     match_events_by_kernel,
 )
-from tritonparse.diff.core.input_resolver import is_remote, resolve_input, ResolvedInput
+from tritonparse.diff.core.input_resolver import (
+    is_remote,
+    resolve_input,
+    ResolvedInput,
+    share_input,
+)
 from tritonparse.diff.output import (
     append_diff_to_file,
     ConsolidatedDiffWriter,
@@ -125,6 +130,31 @@ def _add_diff_args(parser: argparse.ArgumentParser) -> None:
         default=False,
         help="Run AI analysis to explain the root causes of detected differences.",
     )
+    parser.add_argument(
+        "--no-url",
+        action="store_true",
+        default=False,
+        help="Do not print tritonparse website file-diff links.",
+    )
+    parser.add_argument(
+        "--no-share",
+        action="store_true",
+        default=False,
+        help=(
+            "Do not upload local trace files. They are uploaded by default so "
+            "a file-diff link can be produced; pass this to keep them local "
+            "(links for already-remote inputs still print)."
+        ),
+    )
+    parser.add_argument(
+        "--max-urls",
+        type=int,
+        default=10,
+        help=(
+            "Maximum number of per-kernel file-diff links to print in --trace "
+            "mode (default: 10). Use 0 for no limit."
+        ),
+    )
 
 
 def _parse_event_indices(events_str: str) -> tuple[int, int]:
@@ -172,13 +202,91 @@ def _generate_output_path(resolved: ResolvedInput) -> str:
     return f"{base}_diff{ext}"
 
 
-def _resolve_inputs(input_paths: list[str]) -> list[ResolvedInput]:
-    """Fetch any remote inputs and report what was resolved."""
+def _resolve_inputs(input_paths: list[str], share: bool = False) -> list[ResolvedInput]:
+    """Make every input readable locally, and linkable if asked.
+
+    Args:
+        input_paths: User-supplied trace sources.
+        share: Publish local inputs so they can be linked. Only worth doing
+            when a link will actually be printed.
+    """
     resolved = [resolve_input(path) for path in input_paths]
     for original, item in zip(input_paths, resolved):
         if item.json_url is not None:
             logger.info(f"Resolved {original} -> {item.local_path}")
+    if share:
+        resolved = [share_input(item) for item in resolved]
     return resolved
+
+
+def _wants_links(no_url: bool, quiet: bool) -> bool:
+    """Whether this run will print file-diff links.
+
+    Gates the upload too: sharing a local trace is only justified by the link
+    it produces, so a run that prints nothing must not upload anything.
+    """
+    return not no_url and not quiet
+
+
+def _log_file_diff_urls(urls: list[tuple[str, str]], no_url: bool) -> None:
+    """Print website file-diff links, or explain why there are none.
+
+    Args:
+        urls: (label, url) pairs, already truncated by the caller.
+        no_url: If True, print nothing.
+    """
+    if no_url or not urls:
+        return
+    border = "=" * 80
+    logger.info(f"\n{border}")
+    logger.info("🔗 OPEN FILE DIFF (Interactive Visualization, VPN required):")
+    logger.info(border)
+    for label, url in urls:
+        if label:
+            logger.info(f"{label}:")
+        logger.info(url)
+    logger.info(border)
+
+
+def _trace_diff_urls(
+    result,
+    resolved_a: ResolvedInput,
+    resolved_b: ResolvedInput,
+    max_urls: int,
+) -> list[tuple[str, str]]:
+    """Build one file-diff link per changed matched kernel pair.
+
+    Identical pairs are skipped -- a link to a diff with no differences is
+    noise. Returns an empty list when either input has no shareable URL.
+    """
+    if resolved_a.json_url is None or resolved_b.json_url is None:
+        return []
+
+    from tritonparse.diff.fb.url_builder import build_url_for_kernel_pair
+
+    urls: list[tuple[str, str]] = []
+    for match in result.matched_kernels:
+        if match.status == "identical":
+            continue
+        cd = match.compilation_diff
+        urls.append(
+            (
+                f"{match.kernel_name_a} ({match.status})",
+                build_url_for_kernel_pair(
+                    json_url=resolved_a.json_url,
+                    json_b_url=resolved_b.json_url,
+                    hash_a=match.hash_a,
+                    hash_b=match.hash_b,
+                    ir_stats=cd.ir_stats if cd else None,
+                ),
+            )
+        )
+
+    if max_urls > 0 and len(urls) > max_urls:
+        omitted = len(urls) - max_urls
+        urls = urls[:max_urls]
+        urls.append(("", f"... {omitted} more (use --max-urls 0 to show all)"))
+    return urls
 
 
 def trace_diff_command(
@@ -189,6 +297,9 @@ def trace_diff_command(
     atol: float = 1e-5,
     rtol: float = 1e-3,
     ai: bool = False,
+    no_url: bool = False,
+    max_urls: int = 10,
+    no_share: bool = False,
 ) -> None:
     """Run trace-level diff comparing all kernels across two trace files.
 
@@ -200,6 +311,9 @@ def trace_diff_command(
         atol: Absolute tolerance for tensor comparison.
         rtol: Relative tolerance for tensor comparison.
         ai: If True, run AI analysis on qualifying kernels.
+        no_url: If True, suppress website file-diff links.
+        max_urls: Max per-kernel links to print; 0 means no limit.
+        no_share: If True, do not upload local traces.
     """
     from tritonparse.diff.core.trace_diff_engine import TraceDiffEngine
     from tritonparse.diff.output.event_writer import ConsolidatedDiffWriter
@@ -208,7 +322,9 @@ def trace_diff_command(
     if len(input_paths) != 2:
         raise ValueError("--trace requires exactly 2 input files")
 
-    resolved_a, resolved_b = _resolve_inputs(input_paths)
+    resolved_a, resolved_b = _resolve_inputs(
+        input_paths, share=not no_share and _wants_links(no_url, quiet)
+    )
 
     # Load events
     events_a = load_events(resolved_a.local_path)
@@ -229,6 +345,9 @@ def trace_diff_command(
     # Print deterministic diff summary first so user sees results immediately
     if not quiet:
         logger.info(format_trace_summary(result))
+        _log_file_diff_urls(
+            _trace_diff_urls(result, resolved_a, resolved_b, max_urls), no_url
+        )
 
     # Run AI analysis on qualifying kernels after showing the diff
     if ai and result.summary.status != "identical":
@@ -314,6 +433,9 @@ def diff_command(
     rtol: float = 1e-3,
     trace: bool = False,
     ai: bool = False,
+    no_url: bool = False,
+    max_urls: int = 10,
+    no_share: bool = False,
 ) -> None:
     """
     Main function for the diff command.
@@ -331,6 +453,10 @@ def diff_command(
         atol: Absolute tolerance for tensor comparison
         rtol: Relative tolerance for tensor comparison
         trace: If True, compare all kernels across two trace files
+        ai: If True, run AI root-cause analysis
+        no_url: If True, suppress website file-diff links
+        max_urls: Max per-kernel links to print in --trace mode; 0 means no limit
+        no_share: If True, do not upload local traces
     """
     if not skip_logger and is_fbcode():
         from tritonparse.fb.utils import usage_report_logger
@@ -349,6 +475,9 @@ def diff_command(
             atol=atol,
             rtol=rtol,
             ai=ai,
+            no_url=no_url,
+            max_urls=max_urls,
+            no_share=no_share,
         )
 
     # Validate input paths
@@ -367,7 +496,9 @@ def diff_command(
         )
 
     # Load events from first file
-    resolved = _resolve_inputs(input_paths)
+    resolved = _resolve_inputs(
+        input_paths, share=not no_share and _wants_links(no_url, quiet)
+    )
     resolved_a = resolved[0]
     input_path_a = resolved_a.display
     all_events_a = load_events(resolved_a.local_path)
@@ -511,6 +642,24 @@ def diff_command(
     # Print deterministic diff results immediately
     if not quiet:
         logger.info(format_summary(result))
+        if resolved_a.json_url is not None and resolved_b.json_url is not None:
+            from tritonparse.diff.fb.url_builder import build_url_for_kernel_pair
+
+            _log_file_diff_urls(
+                [
+                    (
+                        "",
+                        build_url_for_kernel_pair(
+                            json_url=resolved_a.json_url,
+                            json_b_url=resolved_b.json_url,
+                            hash_a=result.hash_a,
+                            hash_b=result.hash_b,
+                            ir_stats=result.ir_stats,
+                        ),
+                    )
+                ],
+                no_url,
+            )
 
     # Run AI analysis after showing deterministic results
     if ai and result.summary.status != "identical":

--- a/tritonparse/diff/core/input_resolver.py
+++ b/tritonparse/diff/core/input_resolver.py
@@ -5,7 +5,8 @@ Resolve a diff input to a local file, plus a shareable URL when one exists.
 
 OSS accepts local paths only. In fbcode the work is delegated to
 ``tritonparse.diff.fb.input_resolver``, which additionally understands remote
-trace references and can fetch them; that module is not synced to GitHub.
+trace references, can fetch them, and can upload a local trace so the website
+can load it; that module is not synced to GitHub.
 """
 
 from __future__ import annotations
@@ -48,3 +49,16 @@ def resolve_input(source: str) -> ResolvedInput:
 
         return fb_resolve(source)
     return ResolvedInput(local_path=source, display=source)
+
+
+def share_input(resolved: ResolvedInput) -> ResolvedInput:
+    """Publish a local input so the website can fetch it, if possible.
+
+    A no-op in OSS, which has nowhere to publish to: the input is returned
+    unchanged and simply carries no link.
+    """
+    if resolved.json_url is not None or not is_fbcode():
+        return resolved
+    from tritonparse.diff.fb.input_resolver import share_input as fb_share
+
+    return fb_share(resolved)

--- a/tritonparse/diff/core/input_resolver.py
+++ b/tritonparse/diff/core/input_resolver.py
@@ -1,0 +1,50 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Resolve a diff input to a local file, plus a shareable URL when one exists.
+
+OSS accepts local paths only. In fbcode the work is delegated to
+``tritonparse.diff.fb.input_resolver``, which additionally understands remote
+trace references and can fetch them; that module is not synced to GitHub.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tritonparse.shared_vars import is_fbcode
+
+
+@dataclass(frozen=True)
+class ResolvedInput:
+    """A diff input that has been made readable on the local filesystem."""
+
+    # Path to read events from.
+    local_path: str
+    # Original user-supplied string, for display.
+    display: str
+    # Browser-fetchable URL, when one exists for this input. None for purely
+    # local inputs, which cannot be linked.
+    json_url: str | None = None
+
+
+def is_remote(source: str) -> bool:
+    """Whether this input has to be fetched before it can be read.
+
+    Lets callers reject an unsupported combination before paying for the
+    fetch. Always False in OSS, which accepts local paths only.
+    """
+    if not is_fbcode():
+        return False
+    from tritonparse.diff.fb.input_resolver import is_remote as fb_is_remote
+
+    return fb_is_remote(source)
+
+
+def resolve_input(source: str) -> ResolvedInput:
+    """Resolve one diff input to something readable on this filesystem."""
+    if is_fbcode():
+        from tritonparse.diff.fb.input_resolver import resolve_input as fb_resolve
+
+        return fb_resolve(source)
+    return ResolvedInput(local_path=source, display=source)


### PR DESCRIPTION
Summary:
Last of four diffs adding Manifold-URL inputs and File Diff links to
`tritonparse diff`. Completes the feature: two traces in, a clickable File Diff
link out — regardless of whether those traces started local or on Manifold.

Alongside the text summary the diff now prints a tritonparse website file-diff
link: one per changed kernel in `--trace` mode, one for the pair otherwise.

- `diff/fb/url_builder.select_ir()` opens the link on whichever IR stage changed most,
  by absolute line delta, rather than a fixed guess.
- `diff/fb/url_builder.build_url_for_kernel_pair()` always emits `json_b_url`, even
  when identical to `json_url`. The site loads its right pane only from that
  param (`FileDiffView.tsx:197`) and does not fall back to `json_url`.
- Kernels that matched as `identical` are skipped — a link to a diff with no
  differences is noise.
- `--max-urls` (default 10, `0` for no limit) keeps a trace with hundreds of
  kernels from burying the summary. `--no-url` suppresses links entirely.

Local traces are uploaded to Manifold so they can be linked, since the website
can only load a URL it can fetch. This matches how `tritonparse parse` already
behaves — `fb_run()` uploads and prints a URL by default, with `--out` as the
opt-out — rather than inventing a different convention for `diff`.

- `manifold_io.upload_for_sharing()` delegates to the existing
  `ManifoldTraceUploader` (`tritonparse/fb/uploader.py`) rather than
  hand-rolling a second Manifold put. It puts the trace under
  `tlparse_reports/tree/logs/tritonparse_diff/<user>_<host>_<timestamp>/`, with
  a 30-day TTL so local runs do not accumulate in the bucket. One directory per
  run, so re-runs never collide with an existing blob, and each blob is prefixed
  with a hash of its source path so a before/after pair of same-named traces
  does not collide within a run.
- `share_input()` follows the same seam as `resolve_input`: a generic
  dispatcher in `diff/core/input_resolver.py` and the Manifold upload in
  `diff/fb/input_resolver.py`.
- `--no-share` keeps local files local; links for Manifold inputs still print.

Uploading is gated on a link actually being printed (`_wants_links`), so
`--no-url` and `--quiet` runs upload nothing — sharing a trace is only
justified by the link it produces.

Upload failure is deliberately non-fatal. The diff results are the point, and a
missing link only costs a convenience, so a Manifold outage or a permissions
problem warns and prints the diff rather than failing the command.

Raw (unparsed) traces upload fine too: the website's `processKernelData`
defaults `source_mappings` to `{}` (`dataLoader.ts:692`) and the file-diff view
reads only `irFiles`, so a raw trace renders.

Per review, every module that encodes internal infrastructure now lives under
`diff/fb/` (`url_builder`, `remote_input`, `input_resolver`, `manifold_io`), and
their tests under `tests/fb/diff/`. `diff/cli.py` stays shared but imports the
internal URL builder lazily and no longer names Manifold in any user-facing
string, so the OSS `--help` advertises only what an OSS build can do.

Per review, the upload reuses `ManifoldTraceUploader` instead of duplicating
Manifold plumbing. That class was hardcoded to the pyper_traces archive, so it
grew four keyword options -- `path_prefix`, `compress`, `ttl`, `log_to_scuba` --
all defaulting to today's behavior, plus an optional `blob_name` and a return
value (the in-bucket path, or None on failure). Its one existing caller in
`structured_logging.py` uses the defaults and ignores the return, so it is
unaffected.

Three of those options are load-bearing here, and are why the class could not be
reused as-is:
- `compress=False`: the uploader zstd-compresses uncompressed traces, but the
  website reads only gzip and CLP (`dataLoader.ts` `isClpFile` / `isGzipFile`),
  so the default would have produced a blob the site cannot open -- a link that
  loads and shows nothing.
- `ttl`: shared diff traces expire after 30 days; archive uploads do not.
- `log_to_scuba=False`: a share for a diff link is not a benchmark result.

Also fixed there while making it reusable: the Scuba block sat in a `finally`
with a `return` inside it, which would swallow any non-`StorageException`. It is
now a guarded call to a `_log_to_scuba` helper after the try/except.

Differential Revision: D118832012


