### PR TITLE
[website] Add overview ruler for mapped line highlights

### DIFF
--- a/website/src/components/CodeComparisonView.tsx
+++ b/website/src/components/CodeComparisonView.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Panel, Group, Separator } from "react-resizable-panels";
 import CodeViewer from "./CodeViewer";
 import CopyCodeButton from "./CopyCodeButton";
+import { notifyCodeViewerHighlights } from "./highlightEvents";
 import {
     IRFile,
     IRStageDescriptor,
@@ -173,6 +174,7 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
 
             // Update ref (does not trigger re-render)
             highlightedLinesRef.current[viewerId] = lineNumbers;
+            notifyCodeViewerHighlights(viewerId, lineNumbers);
 
             // Smart scrolling: only scroll when necessary, only scroll container
             if (lineNumbers.length > 0) {

--- a/website/src/components/CodeComparisonView.tsx
+++ b/website/src/components/CodeComparisonView.tsx
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates.
 
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Panel, Group, Separator } from "react-resizable-panels";
 import CodeViewer from "./CodeViewer";
 import CopyCodeButton from "./CopyCodeButton";
@@ -147,16 +147,22 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
         viewerId: 'left' | 'right' | 'python',
         lineNumbers: number[]
     ) => {
+        const oldLines = highlightedLinesRef.current[viewerId];
+
+        // Store and publish the latest mapping even when its viewer is hidden.
+        // A remounted viewer can then initialize from the retained ref value.
+        highlightedLinesRef.current[viewerId] = lineNumbers;
+        notifyCodeViewerHighlights(viewerId, lineNumbers);
+
         // Use requestAnimationFrame to ensure CodeViewer components have rendered
         requestAnimationFrame(() => {
             const container = document.querySelector(`[data-viewer-id="${viewerId}"]`) as HTMLElement;
             if (!container) {
-                // CodeViewer not yet rendered, skip update
+                // The state above is retained for a viewer that mounts later.
                 return;
             }
 
             // Remove old highlights
-            const oldLines = highlightedLinesRef.current[viewerId];
             oldLines.forEach(lineNum => {
                 const element = container.querySelector(
                     `[data-line-number="${lineNum}"]`
@@ -171,10 +177,6 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
                 );
                 element?.classList.add('highlighted-line');
             });
-
-            // Update ref (does not trigger re-render)
-            highlightedLinesRef.current[viewerId] = lineNumbers;
-            notifyCodeViewerHighlights(viewerId, lineNumbers);
 
             // Smart scrolling: only scroll when necessary, only scroll container
             if (lineNumbers.length > 0) {
@@ -227,6 +229,23 @@ const CodeComparisonView: React.FC<CodeComparisonViewProps> = ({
         function_start_line: py_code_info?.function_start_line,
         function_end_line: py_code_info?.function_end_line,
     }), [py_code_info]);
+
+    // Panel IDs are stable while their documents can change. Clear the retained
+    // mapping whenever the underlying code or mapping changes so a new document
+    // never inherits markers or highlighted lines from the previous one.
+    useEffect(() => {
+        updateHighlights('left', []);
+        updateHighlights('right', []);
+        updateHighlights('python', []);
+    }, [
+        leftPanel_data.content,
+        leftPanel_data.sourceMapping,
+        rightPanel_data.content,
+        rightPanel_data.sourceMapping,
+        pythonInfo.code,
+        pythonMapping,
+        updateHighlights,
+    ]);
 
     // ==================== Pure Utility Functions ====================
 

--- a/website/src/components/CodeViewer.css
+++ b/website/src/components/CodeViewer.css
@@ -1,3 +1,46 @@
+.code-viewer-overview-wrapper {
+    position: relative;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.code-overview-ruler {
+    position: absolute;
+    top: 4px;
+    right: 3px;
+    bottom: 4px;
+    width: 10px;
+    z-index: 10;
+    border-radius: 5px;
+    background: rgba(100, 116, 139, 0.14);
+    box-shadow: inset 0 0 0 1px rgba(100, 116, 139, 0.2);
+    pointer-events: none;
+}
+
+.code-overview-marker {
+    position: absolute;
+    left: 1px;
+    width: 8px;
+    height: 5px;
+    padding: 0;
+    transform: translateY(-50%);
+    border: 0;
+    border-radius: 2px;
+    background: #f59e0b;
+    box-shadow: 0 0 0 1px rgba(146, 64, 14, 0.45);
+    cursor: pointer;
+    pointer-events: auto;
+}
+
+.code-overview-marker:hover,
+.code-overview-marker:focus-visible {
+    left: 0;
+    width: 10px;
+    background: #d97706;
+    outline: 2px solid #2563eb;
+    outline-offset: 1px;
+}
+
 /* Alias name badge */
 .alias-badge {
     display: inline-block;

--- a/website/src/components/CodeViewer.tsx
+++ b/website/src/components/CodeViewer.tsx
@@ -7,6 +7,7 @@ import {
 import type { SourceMapping } from "../utils/dataLoader";
 import { mapLanguageToHighlighter } from "../utils/languageUtils";
 import {
+  getCodeViewerHighlights,
   HIGHLIGHT_LINES_EVENT,
   type HighlightLinesEventDetail,
 } from "./highlightEvents";
@@ -179,6 +180,15 @@ const splitIntoLines = (code: string): string[] => {
   return code.split('\n');
 };
 
+/** Count logical lines without allocating an array for the full document. */
+const countLines = (code: string): number => {
+  let lineCount = 1;
+  for (let index = 0; index < code.length; index += 1) {
+    if (code.charCodeAt(index) === 10) lineCount += 1;
+  }
+  return lineCount;
+};
+
 interface OverviewRulerProps {
   viewerId?: string;
   lineCount: number;
@@ -199,7 +209,7 @@ const OverviewRuler: React.FC<OverviewRulerProps> = ({
 }) => {
   const [eventHighlightedLines, setEventHighlightedLines] = useState<
     number[] | null
-  >(null);
+  >(() => viewerId ? getCodeViewerHighlights(viewerId) ?? null : null);
   const highlightedLines = eventHighlightedLines ?? initialHighlightedLines;
 
   useEffect(() => {
@@ -785,6 +795,28 @@ const StandardCodeViewer: React.FC<CodeViewerProps> = ({
  * Automatically chooses between standard, optimized, or basic viewer based on code size.
  */
 const CodeViewer: React.FC<CodeViewerProps> = (props) => {
+  const lineCount = useMemo(() => countLines(props.code), [props.code]);
+
+  // Restore retained classes when a viewer (notably the optional Python panel)
+  // mounts after its latest highlight event was published.
+  useEffect(() => {
+    const viewerId = props.viewerId;
+    if (!viewerId) return;
+
+    const frame = requestAnimationFrame(() => {
+      const container = document.querySelector(
+        `[data-viewer-id="${viewerId}"]`
+      );
+      const retainedLines = getCodeViewerHighlights(viewerId);
+      retainedLines?.forEach(lineNumber => {
+        container?.querySelector(`[data-line-number="${lineNumber}"]`)
+          ?.classList.add('highlighted-line');
+      });
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [props.viewerId, props.code]);
+
   // Add inline style for highlighted lines to ensure they're visible
   useEffect(() => {
     if (props.highlightedLines && props.highlightedLines.length > 0) {
@@ -845,8 +877,8 @@ const CodeViewer: React.FC<CodeViewerProps> = (props) => {
       <OverviewRuler
         key={props.viewerId}
         viewerId={props.viewerId}
-        lineCount={splitIntoLines(props.code).length}
-        startingLineNumber={props.startingLineNumber || 1}
+        lineCount={lineCount}
+        startingLineNumber={props.startingLineNumber ?? 1}
         initialHighlightedLines={
           props.highlightedLines ?? EMPTY_HIGHLIGHTED_LINES
         }

--- a/website/src/components/CodeViewer.tsx
+++ b/website/src/components/CodeViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import {
   oneLight,
@@ -6,6 +6,10 @@ import {
 } from "react-syntax-highlighter/dist/esm/styles/prism";
 import type { SourceMapping } from "../utils/dataLoader";
 import { mapLanguageToHighlighter } from "../utils/languageUtils";
+import {
+  HIGHLIGHT_LINES_EVENT,
+  type HighlightLinesEventDetail,
+} from "./highlightEvents";
 import "./CodeViewer.css";
 
 // Import language support
@@ -25,6 +29,8 @@ SyntaxHighlighter.registerLanguage('python', python);
 
 const LARGE_FILE_THRESHOLD = 10000000;
 const EXTREMELY_LARGE_FILE_THRESHOLD = 10000000;
+
+const EMPTY_HIGHLIGHTED_LINES: number[] = [];
 
 // Global scroll position storage to persist across re-renders
 const scrollPositionStore = new Map<string, number>();
@@ -173,6 +179,106 @@ const splitIntoLines = (code: string): string[] => {
   return code.split('\n');
 };
 
+interface OverviewRulerProps {
+  viewerId?: string;
+  lineCount: number;
+  startingLineNumber: number;
+  initialHighlightedLines: number[];
+}
+
+/**
+ * A lightweight overview of highlighted logical lines in the full file.
+ * Highlight updates are delivered separately from the code viewer props so
+ * changing a mapping does not re-render a large syntax-highlighted document.
+ */
+const OverviewRuler: React.FC<OverviewRulerProps> = ({
+  viewerId,
+  lineCount,
+  startingLineNumber,
+  initialHighlightedLines,
+}) => {
+  const [eventHighlightedLines, setEventHighlightedLines] = useState<
+    number[] | null
+  >(null);
+  const highlightedLines = eventHighlightedLines ?? initialHighlightedLines;
+
+  useEffect(() => {
+    if (!viewerId) return;
+
+    const handleHighlightLines = (event: Event) => {
+      const detail = (event as CustomEvent<HighlightLinesEventDetail>).detail;
+      if (detail.viewerId === viewerId) {
+        setEventHighlightedLines(detail.lineNumbers);
+      }
+    };
+
+    window.addEventListener(HIGHLIGHT_LINES_EVENT, handleHighlightLines);
+    return () => {
+      window.removeEventListener(HIGHLIGHT_LINES_EVENT, handleHighlightLines);
+    };
+  }, [viewerId]);
+
+  const lastLineNumber = startingLineNumber + lineCount - 1;
+  const visibleMarkers = useMemo(
+    () => Array.from(new Set(highlightedLines))
+      .filter(line => line >= startingLineNumber && line <= lastLineNumber)
+      .sort((a, b) => a - b),
+    [highlightedLines, startingLineNumber, lastLineNumber]
+  );
+
+  const scrollToLine = useCallback((lineNumber: number) => {
+    if (!viewerId) return;
+
+    const container = document.querySelector(
+      `[data-viewer-id="${viewerId}"]`
+    ) as HTMLElement | null;
+    if (!container) return;
+
+    const target = container.querySelector(
+      `[data-line-number="${lineNumber}"]`
+    ) as HTMLElement | null;
+    if (target) {
+      const containerRect = container.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      const centeredTop = container.scrollTop + targetRect.top -
+        containerRect.top - container.clientHeight / 2;
+      container.scrollTo({ top: Math.max(0, centeredTop), behavior: "smooth" });
+      return;
+    }
+
+    // A virtualized viewer may not have the requested line in the DOM yet.
+    const fraction = lineCount <= 1
+      ? 0
+      : (lineNumber - startingLineNumber) / (lineCount - 1);
+    const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    container.scrollTo({ top: fraction * maxScrollTop, behavior: "smooth" });
+  }, [viewerId, lineCount, startingLineNumber]);
+
+  if (!viewerId) return null;
+
+  return (
+    <div className="code-overview-ruler" aria-label="Highlighted lines overview">
+      {visibleMarkers.map(lineNumber => {
+        const rawPosition = lineCount <= 1
+          ? 0
+          : ((lineNumber - startingLineNumber) / (lineCount - 1)) * 100;
+        const position = Math.min(98, Math.max(2, rawPosition));
+        return (
+          <button
+            key={lineNumber}
+            type="button"
+            className="code-overview-marker"
+            style={{ top: `${position}%` }}
+            aria-label={`Scroll to highlighted line ${lineNumber}`}
+            title={`Line ${lineNumber}`}
+            onClick={() => scrollToLine(lineNumber)}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
 /**
  * Creates a debounced function that delays invoking func until after wait milliseconds
  * @param func The function to debounce
@@ -205,6 +311,7 @@ const BasicCodeViewer: React.FC<CodeViewerProps> = ({
   initialScrollToLine,
   functionStartLine,
   functionEndLine,
+  startingLineNumber = 1,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const lines = splitIntoLines(code);
@@ -266,7 +373,7 @@ const BasicCodeViewer: React.FC<CodeViewerProps> = ({
       }}>
         <code>
           {lines.map((line, index) => {
-            const lineNumber = index + 1;
+            const lineNumber = index + startingLineNumber;
             const isHighlighted = highlightedLines.includes(lineNumber);
 
             // Check if line is in function range
@@ -718,14 +825,34 @@ const CodeViewer: React.FC<CodeViewerProps> = (props) => {
     );
   }
 
-  // Use optimized viewer for large files
+  // Keep the ruler outside the scroll container so it remains visible while
+  // the code moves underneath it.
+  let viewer: React.ReactNode;
   if (props.code.length > EXTREMELY_LARGE_FILE_THRESHOLD) {
-    return <BasicCodeViewer {...props} />;
+    viewer = <BasicCodeViewer {...props} height="100%" />;
   } else if (props.code.length > LARGE_FILE_THRESHOLD) {
-    return <LargeFileViewer {...props} />;
+    viewer = <LargeFileViewer {...props} height="100%" />;
   } else {
-    return <StandardCodeViewer {...props} />;
+    viewer = <StandardCodeViewer {...props} height="100%" />;
   }
+
+  return (
+    <div
+      className="code-viewer-overview-wrapper"
+      style={{ height: props.height || "100%" }}
+    >
+      {viewer}
+      <OverviewRuler
+        key={props.viewerId}
+        viewerId={props.viewerId}
+        lineCount={splitIntoLines(props.code).length}
+        startingLineNumber={props.startingLineNumber || 1}
+        initialHighlightedLines={
+          props.highlightedLines ?? EMPTY_HIGHLIGHTED_LINES
+        }
+      />
+    </div>
+  );
 };
 
 // Use React.memo to prevent unnecessary re-renders

--- a/website/src/components/highlightEvents.ts
+++ b/website/src/components/highlightEvents.ts
@@ -1,0 +1,16 @@
+export const HIGHLIGHT_LINES_EVENT = "tritonparse:highlight-lines";
+
+export interface HighlightLinesEventDetail {
+  viewerId: string;
+  lineNumbers: number[];
+}
+
+export const notifyCodeViewerHighlights = (
+  viewerId: string,
+  lineNumbers: number[]
+) => {
+  window.dispatchEvent(new CustomEvent<HighlightLinesEventDetail>(
+    HIGHLIGHT_LINES_EVENT,
+    { detail: { viewerId, lineNumbers } }
+  ));
+};

--- a/website/src/components/highlightEvents.ts
+++ b/website/src/components/highlightEvents.ts
@@ -5,10 +5,17 @@ export interface HighlightLinesEventDetail {
   lineNumbers: number[];
 }
 
+const currentHighlights = new Map<string, number[]>();
+
+export const getCodeViewerHighlights = (
+  viewerId: string
+): number[] | undefined => currentHighlights.get(viewerId);
+
 export const notifyCodeViewerHighlights = (
   viewerId: string,
   lineNumbers: number[]
 ) => {
+  currentHighlights.set(viewerId, lineNumbers);
   window.dispatchEvent(new CustomEvent<HighlightLinesEventDetail>(
     HIGHLIGHT_LINES_EVENT,
     { detail: { viewerId, lineNumbers } }


### PR DESCRIPTION
## Summary

- add a slim overview ruler to the left IR, right IR, and Python code viewers
- synchronize markers with mapped-line updates without re-rendering the syntax-highlighted document
- preserve the latest mapped highlights while a panel is hidden and restore them when it remounts
- clear stale highlights when a selected document or source mapping changes
- make markers keyboard accessible and clickable to reveal their corresponding logical lines
- count lines without allocating a second full-file line array
- account for non-1 starting line numbers in the basic large-file renderer

Fixes #422.

## Screenshots

Clicking TTGIR line 88 highlights its mapped PTX lines and Python source line. The orange ticks at the right edge of each viewer show those matches across the full document.

![Overview rulers across TTGIR, PTX, and Python](https://raw.githubusercontent.com/jask1m/tritonparse/pr-assets-433/pr/433/overview-rulers.jpg)

PTX ruler detail, including distant mapped-line markers and the currently visible target:

![PTX overview ruler detail](https://raw.githubusercontent.com/jask1m/tritonparse/pr-assets-433/pr/433/ptx-ruler-detail.jpg)

## Testing

- `npm run lint`
- `npm run build`
- `npm run build:single`
- manually verified all three rulers with a local trace, including multiple distant markers and marker navigation
- manually verified that hiding and restoring the Python panel retains the current mapping
- manually verified that changing an IR selection clears stale markers from every panel
- manually verified that changing the selection while Python is hidden does not restore an obsolete mapping
